### PR TITLE
Improve SharePoint list item field retrieval and task synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,15 @@ role=list_item.roles
 
 | Key | Value |
 | --- | --- |
-| list_item.title | The title of the list item. |
-| list_item.content | The text contents of the list item |
+| list_item.title | The title of the list item (extracted from Title, LinkTitle, or FileLeafRef fields). |
+| list_item.content | The text contents of the list item (extracted from Body, Description, Comments, or Notes fields) |
 | list_item.fields | All fields and values from the SharePoint list item |
 | list_item.created | The time at which the list item was created. |
 | list_item.modified | The last time the list item was modified. |
 | list_item.url | A link for opening the list item in SharePoint. |
 | list_item.roles | A users/groups who can access the list item. |
+
+**Note**: The plugin automatically expands SharePoint list item fields to ensure content extraction. If fields are not initially available, it performs an individual API call with `$expand=fields` to retrieve the complete field data.
 
 ### Configuration Parameters
 

--- a/src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java
+++ b/src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java
@@ -698,7 +698,11 @@ public class Microsoft365Client implements Closeable {
      * @param consumer A consumer to process each ListItem object.
      */
     public void getListItems(final String siteId, final String listId, final Consumer<ListItem> consumer) {
-        ListItemCollectionResponse response = client.sites().bySiteId(siteId).lists().byListId(listId).items().get();
+        // Get list items with expanded fields to ensure content is available
+        ListItemCollectionResponse response = client.sites().bySiteId(siteId).lists().byListId(listId).items().get(config -> {
+            config.queryParameters.expand = new String[] { "fields" };
+            config.queryParameters.select = new String[] { "id", "createdDateTime", "lastModifiedDateTime", "webUrl", "fields" };
+        });
 
         // Handle pagination with odata.nextLink
         while (response != null && response.getValue() != null) {
@@ -725,6 +729,26 @@ public class Microsoft365Client implements Closeable {
      */
     public ListItem getListItem(final String siteId, final String listId, final String itemId) {
         return client.sites().bySiteId(siteId).lists().byListId(listId).items().byListItemId(itemId).get();
+    }
+
+    /**
+     * Retrieves a specific list item with expanded fields.
+     *
+     * @param siteId The ID of the site.
+     * @param listId The ID of the list.
+     * @param itemId The ID of the list item.
+     * @param expandFields Whether to expand the fields property.
+     * @return The ListItem object with expanded fields.
+     */
+    public ListItem getListItem(final String siteId, final String listId, final String itemId, final boolean expandFields) {
+        if (expandFields) {
+            return client.sites().bySiteId(siteId).lists().byListId(listId).items().byListItemId(itemId).get(config -> {
+                config.queryParameters.expand = new String[] { "fields" };
+                config.queryParameters.select = new String[] { "id", "createdDateTime", "lastModifiedDateTime", "webUrl", "fields" };
+            });
+        } else {
+            return getListItem(siteId, listId, itemId);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR enhances the SharePoint list data store to ensure reliable retrieval of list item fields and better handling of asynchronous task execution.

Key changes:

- README.md
  - Clarified list_item.title and list_item.content field descriptions with details on source fields.
  - Added a note explaining automatic expansion of SharePoint list item fields using $expand=fields.
- SharePointListDataStore
  - Introduced CopyOnWriteArrayList<Future<?>> to track submitted tasks and wait for their completion.
  - Ensured executor service waits up to 30 minutes for graceful termination before forcing shutdown.
  - Added commit of remaining buffered documents after shutdown.
- Implemented retry logic for fetching list item fields if they are missing, by re-requesting with expanded fields.
- Microsoft365Client
  - Modified getListItems to request expanded fields ($expand=fields) and selected key properties.
  - Added new getListItem(..., expandFields) method to fetch a specific item with expanded fields.

Benefits:

- Ensures complete field data is retrieved even when not initially available.
- Prevents premature shutdown of executor service by waiting for all tasks.
- Improves reliability of indexing and reduces risk of missing data.