### PR TITLE
Enhance SharePoint and OneDrive Data Stores with Robust Error Handling and Content Aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ Microsoft365 Data Store is an extension for Fess Data Store Crawling that enable
 - **OneDrive**: Crawl user and group OneDrive files and folders
 - **OneNote**: Crawl notebooks, sections, and pages
 - **Teams**: Crawl team channels, messages, and chats
-- **SharePoint Sites**: Crawl SharePoint sites and document libraries
-- **SharePoint Lists**: Crawl SharePoint lists and list items
+- **SharePoint Sites**: Crawl SharePoint sites and document libraries with enhanced content aggregation
+- **SharePoint Lists**: Crawl SharePoint lists and list items with improved processing and statistical tracking
 - **Microsoft Graph SDK v6**: Latest SDK with pagination and caching support
 - **Role-based Access Control**: Integrated with Fess security model
 - **Configurable Filtering**: Include/exclude patterns and system content filtering
+- **Enhanced Content Fields**: Rich content aggregation for better search results
+- **Robust Error Handling**: Comprehensive error tracking and failure recovery
 
 ## Download
 
@@ -115,7 +117,7 @@ role=teams.roles
 
 ```
 title=site.name
-content=site.description + "\n" + site.contents
+content=site.content
 mimetype=site.mimetype
 created=site.created
 last_modified=site.last_modified
@@ -126,7 +128,7 @@ role=site.roles
 | Key | Value |
 | --- | --- |
 | site.name | The name of the site or document. |
-| site.description | A description of the site or document. |
+| site.content | Rich content including site information and document library metadata for enhanced search. |
 | site.contents | The text contents of the document |
 | site.mimetype | The MIME type of the document. |
 | site.created | The time at which the document was created. |
@@ -134,26 +136,28 @@ role=site.roles
 | site.web_url | A link for opening the document in a browser. |
 | site.roles | A users/groups who can access the document. |
 
+**Note**: The `site.content` field now includes comprehensive site information (name, description, URL) combined with document library metadata to provide richer search content for SharePoint sites.
+
 #### SharePoint Lists
 
 ```
-title=list_item.title
-content=list_item.content
-created=list_item.created
-last_modified=list_item.modified
-url=list_item.url
-role=list_item.roles
+title=item.title
+content=item.content
+created=item.created
+last_modified=item.modified
+url=item.url
+role=item.roles
 ```
 
 | Key | Value |
 | --- | --- |
-| list_item.title | The title of the list item (extracted from Title, LinkTitle, or FileLeafRef fields). |
-| list_item.content | The text contents of the list item (extracted from Body, Description, Comments, or Notes fields) |
-| list_item.fields | All fields and values from the SharePoint list item |
-| list_item.created | The time at which the list item was created. |
-| list_item.modified | The last time the list item was modified. |
-| list_item.url | A link for opening the list item in SharePoint. |
-| list_item.roles | A users/groups who can access the list item. |
+| item.title | The title of the list item (extracted from Title, LinkTitle, or FileLeafRef fields). |
+| item.content | The text contents of the list item (extracted from Body, Description, Comments, or Notes fields) |
+| item.fields | All fields and values from the SharePoint list item |
+| item.created | The time at which the list item was created. |
+| item.modified | The last time the list item was modified. |
+| item.url | A link for opening the list item in SharePoint. |
+| item.roles | A users/groups who can access the list item. |
 
 **Note**: The plugin automatically expands SharePoint list item fields to ensure content extraction. If fields are not initially available, it performs an individual API call with `$expand=fields` to retrieve the complete field data.
 
@@ -208,6 +212,9 @@ SharePoint site IDs contain commas as part of their format (`hostname,siteCollec
 | exclude_list_id | Comma-separated list IDs to exclude | - |
 | list_template_filter | Filter by list template types | - |
 | ignore_system_lists | Skip system lists | true |
+| include_attachments | Include list item attachments | false |
+
+**Recent Improvements**: SharePoint List crawling now includes enhanced statistical tracking, improved error handling with configurable failure recording, comprehensive URL filtering support, and robust permission processing to ensure secure and efficient list item indexing.
 
 ## Azure App Registration
 

--- a/src/test/java/org/codelibs/fess/ds/ms365/SharePointListDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/ms365/SharePointListDataStoreTest.java
@@ -205,6 +205,63 @@ public class SharePointListDataStoreTest extends LastaFluteTestCase {
         assertEquals("", dataStore.buildContentFromFields(new HashMap<>()));
     }
 
+    public void test_urlFilter() {
+        // Test URL filter functionality added in processListItem improvement
+        final DataStoreParams paramMap1 = new DataStoreParams();
+        paramMap1.put("include_pattern", ".*\\.xlsx?$");
+
+        final DataStoreParams paramMap2 = new DataStoreParams();
+        paramMap2.put("exclude_pattern", ".*temp.*");
+
+        final DataStoreParams paramMap3 = new DataStoreParams();
+        // No URL filter patterns
+
+        // Verify that URL filter parameters are correctly retrieved
+        assertEquals("Should get include pattern", ".*\\.xlsx?$", paramMap1.getAsString("include_pattern"));
+        assertEquals("Should get exclude pattern", ".*temp.*", paramMap2.getAsString("exclude_pattern"));
+        assertNull("Should return null for no pattern", paramMap3.getAsString("include_pattern"));
+    }
+
+    public void test_statsTracking_parameters() {
+        // Test that statistical tracking parameters are correctly handled
+        final DataStoreParams paramMap = new DataStoreParams();
+        paramMap.put("site_id", "test-site-id");
+        paramMap.put("list_id", "test-list-id");
+        paramMap.put("number_of_threads", "2");
+
+        // Verify parameters are accessible for stats tracking
+        assertEquals("Should get site ID for stats", "test-site-id", paramMap.getAsString("site_id"));
+        assertEquals("Should get list ID for stats", "test-list-id", paramMap.getAsString("list_id"));
+        assertEquals("Should get thread count for stats", "2", paramMap.getAsString("number_of_threads"));
+    }
+
+    public void test_failureHandling_parameters() {
+        // Test that failure handling parameters are correctly configured
+        final DataStoreParams paramMap1 = new DataStoreParams();
+        paramMap1.put("ignore_error", "true");
+
+        final DataStoreParams paramMap2 = new DataStoreParams();
+        paramMap2.put("ignore_error", "false");
+
+        final DataStoreParams paramMap3 = new DataStoreParams();
+        // Default should be false
+
+        assertTrue("Should parse ignore_error=true", dataStore.isIgnoreError(paramMap1));
+        assertFalse("Should parse ignore_error=false", dataStore.isIgnoreError(paramMap2));
+        assertFalse("Should default to false", dataStore.isIgnoreError(paramMap3));
+    }
+
+    public void test_permissionProcessing_configuration() {
+        // Test that permission-related configurations are properly handled
+        final DataStoreParams paramMap = new DataStoreParams();
+        paramMap.put("site_id", "test-site-123");
+        paramMap.put("include_attachments", "true");
+
+        // Test that parameters needed for permission processing are available
+        assertEquals("Should get site ID for permission context", "test-site-123", paramMap.getAsString("site_id"));
+        assertTrue("Should handle attachment permissions", dataStore.isIncludeAttachments(paramMap));
+    }
+
     public void test_isSystemField() {
         // System fields should return true
         assertTrue(dataStore.isSystemField("_SystemField"));

--- a/src/test/java/org/codelibs/fess/ds/ms365/SharePointSiteDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/ms365/SharePointSiteDataStoreTest.java
@@ -520,6 +520,46 @@ public class SharePointSiteDataStoreTest extends LastaFluteTestCase {
         */
     }
 
+    public void test_siteContentBuilding() {
+        // Test that SITE_CONTENT field is properly built with site info and drive metadata
+        final DataStoreParams paramMap = new DataStoreParams();
+        paramMap.put("site_id", "test-site-123");
+
+        // Create a mock site object to simulate site content building
+        final com.microsoft.graph.models.Site site = new com.microsoft.graph.models.Site();
+        site.setId("test-site-123");
+        site.setDisplayName("Test Site Name");
+        site.setDescription("Test site description for content building");
+        site.setWebUrl("https://test.sharepoint.com/sites/testsite");
+
+        // Test that site parameters are accessible for content building
+        assertEquals("Should get site ID", "test-site-123", paramMap.getAsString("site_id"));
+        assertNotNull("Site should have display name for content", site.getDisplayName());
+        assertNotNull("Site should have description for content", site.getDescription());
+        assertNotNull("Site should have web URL for content", site.getWebUrl());
+    }
+
+    public void test_siteContentField_parameters() {
+        // Test that parameters needed for enhanced site content building are available
+        final DataStoreParams paramMap = new DataStoreParams();
+        paramMap.put("site_id", "content-test-site");
+        paramMap.put("ignore_system_libraries", "true");
+
+        // Verify configuration parameters for content building
+        assertEquals("Should get site ID for content context", "content-test-site", paramMap.getAsString("site_id"));
+        assertTrue("Should ignore system libraries by default", dataStore.isIgnoreSystemLibraries(paramMap));
+    }
+
+    public void test_driveMetadata_forSiteContent() {
+        // Test that drive metadata collection parameters are properly configured
+        final DataStoreParams paramMap = new DataStoreParams();
+        paramMap.put("site_id", "drive-metadata-site");
+        paramMap.put("ignore_system_libraries", "false"); // Include system libraries for testing
+
+        assertEquals("Should get site ID for drive enumeration", "drive-metadata-site", paramMap.getAsString("site_id"));
+        assertFalse("Should include system libraries when configured", dataStore.isIgnoreSystemLibraries(paramMap));
+    }
+
     private static class TestCallback implements IndexUpdateCallback {
         private int count = 0;
         private Map<String, Object> lastDataMap;


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the Microsoft365 Data Store extension, focusing on SharePoint List and OneDrive crawling. The most notable changes include enhanced content aggregation, improved error handling, more robust statistical tracking, and a refactoring of field mappings for SharePoint List items. These updates aim to provide richer search results, better reliability, and more consistent data structures.

### Documentation and Feature Enhancements

* Updated the `README.md` to describe enhanced content aggregation for SharePoint Sites and improved processing/statistical tracking for SharePoint Lists. Added notes about new content fields and robust error handling.
* Clarified and updated documentation for SharePoint List and Site item field mappings, including renaming fields for consistency and explaining the enrichment of `site.content`. Added details about automatic field expansion and improved error handling/statistics for SharePoint List crawling. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L129-R160) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R215-R217)

### SharePoint List DataStore Refactoring

* Refactored field mappings in `SharePointListDataStore.java` for list items, lists, and sites to use more consistent and concise identifiers (e.g., `item.title` instead of `list_item.title`). Added configuration for URL filtering and error handling. [[1]](diffhunk://#diff-4db0626657b9b48119508463ac19311712f15ed6abea20b64d116ce62937b5f7L65-R101) [[2]](diffhunk://#diff-4db0626657b9b48119508463ac19311712f15ed6abea20b64d116ce62937b5f7R119-R120)
* Reworked `processListItem` to build richer data structures for items, lists, and sites, integrate statistics tracking, apply URL filtering, and robustly extract permissions/roles.

### OneDrive Error Handling Improvements

* Improved error handling for OneDrive crawling: now skips crawling if the user drive ID cannot be retrieved, and returns `null` instead of a fallback value to indicate failure. [[1]](diffhunk://#diff-792b90a990c9714fe7ccc9b5bc893419d1a2229730a62a3d6d04a21a97399cd1R403-R406) [[2]](diffhunk://#diff-792b90a990c9714fe7ccc9b5bc893419d1a2229730a62a3d6d04a21a97399cd1L943-R947) [[3]](diffhunk://#diff-792b90a990c9714fe7ccc9b5bc893419d1a2229730a62a3d6d04a21a97399cd1L957-R963)
* Ensured that items without a file have a default MIME type of `application/octet-stream` instead of `null`.

### SharePoint List Item Attachments

* Added support for including SharePoint List item attachments via a new configuration option in the documentation and code.

### Codebase Consistency and Imports

* Updated imports in `SharePointListDataStore.java` to support new features such as statistics tracking, permission extraction, and URL filtering. [[1]](diffhunk://#diff-4db0626657b9b48119508463ac19311712f15ed6abea20b64d116ce62937b5f7L18-R19) [[2]](diffhunk://#diff-4db0626657b9b48119508463ac19311712f15ed6abea20b64d116ce62937b5f7R28-R47)