### PR TITLE
Remove unsupported orderby parameter with ConsistencyLevel:eventual in Microsoft365Client queries

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java
+++ b/src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java
@@ -331,7 +331,7 @@ public class Microsoft365Client implements Closeable {
                     new String[] { "id", "displayName", "mail", "userPrincipalName", "assignedLicenses" };
             // Filter for licensed users only to reduce data transfer
             requestConfiguration.queryParameters.filter = "assignedLicenses/$count ne 0";
-            requestConfiguration.queryParameters.orderby = new String[] { "displayName" };
+            // Removed orderby as it's not supported with $count filter and ConsistencyLevel:eventual
             // Required for advanced queries
             requestConfiguration.headers.add("ConsistencyLevel", "eventual");
         });
@@ -409,7 +409,7 @@ public class Microsoft365Client implements Closeable {
             // Select only essential fields to improve performance
             requestConfiguration.queryParameters.select =
                     new String[] { "id", "displayName", "mail", "groupTypes", "resourceProvisioningOptions" };
-            requestConfiguration.queryParameters.orderby = new String[] { "displayName" };
+            // Removed orderby as it's not supported with advanced filters and ConsistencyLevel:eventual
             // Required for advanced queries
             requestConfiguration.headers.add("ConsistencyLevel", "eventual");
         });
@@ -883,7 +883,7 @@ public class Microsoft365Client implements Closeable {
             // Select only essential fields to improve performance
             requestConfiguration.queryParameters.select =
                     new String[] { "id", "displayName", "mail", "description", "resourceProvisioningOptions" };
-            requestConfiguration.queryParameters.orderby = new String[] { "displayName" };
+            // Removed orderby as it's not supported with advanced filters and ConsistencyLevel:eventual
             // Required for advanced queries
             requestConfiguration.headers.add("ConsistencyLevel", "eventual");
         });


### PR DESCRIPTION
This pull request makes a targeted update to the Microsoft 365 client code by removing the use of the `orderby` parameter in several API requests. This change addresses compatibility issues when using advanced filters and the `ConsistencyLevel:eventual` header, which do not support ordering results. The update improves reliability and ensures correct data retrieval from the Microsoft Graph API.

API request compatibility improvements:

* Removed the `orderby` parameter from user queries in `getUsers`, with a comment explaining that it is not supported when using `$count` filters and `ConsistencyLevel:eventual`. (`src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java`)
* Removed the `orderby` parameter from group queries in `getMicrosoft365Groups`, with a comment noting incompatibility with advanced filters and `ConsistencyLevel:eventual`. (`src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java`)
* Removed the `orderby` parameter from team queries in `geTeams`, with a similar comment about advanced filters and consistency level. (`src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java`)