### PR TITLE
Refactor Microsoft 365 DataStores: Improve SharePoint/OneDrive handling and documentation

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/ms365/Microsoft365Constants.java
+++ b/src/main/java/org/codelibs/fess/ds/ms365/Microsoft365Constants.java
@@ -41,6 +41,8 @@ public final class Microsoft365Constants {
     public static final String LIST_ITEM_TITLE_KEY = "listItemTitle";
     /** Key for storing the SharePoint site name in additional data. */
     public static final String SITE_NAME_KEY = "siteName";
+    /** Key for storing the SharePoint site URL in additional data. */
+    public static final String SITE_URL_KEY = "siteUrl";
     /** Key for storing the SharePoint list name in additional data. */
     public static final String LIST_NAME_KEY = "listName";
     /** Key for storing the SharePoint list template type in additional data. */
@@ -83,4 +85,27 @@ public final class Microsoft365Constants {
     // Default values
     /** Default value used when the list template type is unknown. */
     public static final String UNKNOWN_TEMPLATE = "unknown";
+    /** SharePoint list template type for document libraries. */
+    public static final String DOCUMENT_LIBRARY = "documentLibrary";
+    /** SharePoint list template type for generic lists. */
+    public static final String GENERIC_LIST = "genericList";
+
+    // SharePoint Authentication Notes
+    /**
+     * For SharePoint list attachments access, the Azure App Registration requires:
+     *
+     * 1. Microsoft Graph API Permissions (for basic site/list operations):
+     *    - Sites.Read.All or Sites.ReadWrite.All
+     *    - Files.Read.All (if accessing files)
+     *
+     * 2. SharePoint Permissions (for REST API access to attachments):
+     *    - The app must be granted access to the specific SharePoint tenant
+     *    - Scope: https://{tenant}.sharepoint.com/.default
+     *    - Note: Some endpoints may require delegated permissions rather than app-only
+     *
+     * 3. Authentication Flow:
+     *    - Use Microsoft Graph SDK for site/list metadata
+     *    - Use SharePoint REST API with proper scopes for attachments
+     *    - Token scope must match the target API (Graph vs SharePoint)
+     */
 }

--- a/src/main/java/org/codelibs/fess/ds/ms365/OneDriveDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/ms365/OneDriveDataStore.java
@@ -1318,7 +1318,7 @@ public class OneDriveDataStore extends Microsoft365DataStore {
                     return;
                 }
             } catch (final Exception e) {
-                logger.warn("Failed to validate drive ID {} for attachment: {}}", driveId, virtualAttachment.getName(), e);
+                logger.warn("Failed to validate drive ID {} for attachment: {}", driveId, virtualAttachment.getName(), e);
                 return;
             }
         }

--- a/src/main/java/org/codelibs/fess/ds/ms365/OneDriveDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/ms365/OneDriveDataStore.java
@@ -56,6 +56,7 @@ import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.codelibs.core.CoreLibConstants;
 import org.codelibs.core.exception.InterruptedRuntimeException;
 import org.codelibs.core.lang.StringUtil;
 import org.codelibs.core.stream.StreamUtil;
@@ -83,7 +84,6 @@ import com.microsoft.graph.models.DriveItem;
 import com.microsoft.graph.models.DriveItemCollectionResponse;
 import com.microsoft.graph.models.Hashes;
 import com.microsoft.graph.models.ListItem;
-import com.microsoft.graph.models.Permission;
 import com.microsoft.graph.models.Site;
 import com.microsoft.kiota.ApiException;
 
@@ -251,9 +251,10 @@ public class OneDriveDataStore extends Microsoft365DataStore {
         configMap.put(URL_FILTER, getUrlFilter(paramMap));
         if (logger.isDebugEnabled()) {
             logger.debug(
-                    "OneDrive crawling started with configuration - MaxSize: {}, IgnoreFolder: {}, IgnoreError: {}, MimeTypes: {}, Threads: {}",
+                    "OneDrive crawling started with configuration - MaxSize: {}, IgnoreFolder: {}, IgnoreError: {}, MimeTypes: {}, Threads: {}, IgnoreSystemLists: {}, IgnoreSystemLibraries: {}",
                     configMap.get(MAX_CONTENT_LENGTH), configMap.get(IGNORE_FOLDER), configMap.get(IGNORE_ERROR),
-                    java.util.Arrays.toString((String[]) configMap.get(SUPPORTED_MIMETYPES)), paramMap.getAsString(NUMBER_OF_THREADS, "1"));
+                    java.util.Arrays.toString((String[]) configMap.get(SUPPORTED_MIMETYPES)), paramMap.getAsString(NUMBER_OF_THREADS, "1"),
+                    isIgnoreSystemLists(paramMap), isIgnoreSystemLibraries(paramMap));
         }
 
         final ExecutorService executorService = newFixedThreadPool(Integer.parseInt(paramMap.getAsString(NUMBER_OF_THREADS, "1")));
@@ -338,7 +339,8 @@ public class OneDriveDataStore extends Microsoft365DataStore {
                 configMap.put(CURRENT_CRAWLER, "list_attachments");
 
                 // Initialize list template types filter
-                final String templateFilter = paramMap.getAsString(LIST_TEMPLATE_FILTER, "documentLibrary,genericList");
+                final String templateFilter = paramMap.getAsString(LIST_TEMPLATE_FILTER,
+                        Microsoft365Constants.DOCUMENT_LIBRARY + "," + Microsoft365Constants.GENERIC_LIST);
                 final String[] templateTypes = templateFilter.split(",");
                 for (int i = 0; i < templateTypes.length; i++) {
                     templateTypes[i] = templateTypes[i].trim();
@@ -442,16 +444,6 @@ public class OneDriveDataStore extends Microsoft365DataStore {
     }
 
     /**
-     * Checks if errors should be ignored.
-     *
-     * @param paramMap The data store parameters.
-     * @return true if errors should be ignored, false otherwise.
-     */
-    protected boolean isIgnoreError(final DataStoreParams paramMap) {
-        return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(IGNORE_ERROR, Constants.TRUE));
-    }
-
-    /**
      * Gets the maximum content length from the data store parameters.
      *
      * @param paramMap The data store parameters.
@@ -509,10 +501,23 @@ public class OneDriveDataStore extends Microsoft365DataStore {
         }
 
         try {
-            getDriveItemsInDrive(client, actualDriveId, item -> executorService.execute(() -> processDriveItem(dataConfig, callback,
-                    configMap, paramMap, scriptMap, defaultDataMap, client, actualDriveId, item, Collections.emptyList())));
+            // Get drive information to check if it's a system library
+            final Drive drive = client.getDrive(actualDriveId);
             if (logger.isDebugEnabled()) {
-                logger.debug("Successfully initiated drive items processing for drive: {}", actualDriveId);
+                logger.debug("Retrieved drive info - Name: {}, DriveType: {}, System: {}", drive.getName(), drive.getDriveType(),
+                        isSystemLibrary(drive));
+            }
+
+            if (Microsoft365Constants.DOCUMENT_LIBRARY.equals(drive.getDriveType())
+                    && (!isIgnoreSystemLibraries(paramMap) || !isSystemLibrary(drive))) {
+                getDriveItemsInDrive(client, actualDriveId, item -> executorService.execute(() -> processDriveItem(dataConfig, callback,
+                        configMap, paramMap, scriptMap, defaultDataMap, client, actualDriveId, item, Collections.emptyList())));
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Successfully initiated drive items processing for drive: {}", actualDriveId);
+                }
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("Skipping shared documents drive: {} - Type: {}, System: {}", drive.getName(), drive.getDriveType(),
+                        isSystemLibrary(drive));
             }
         } catch (final Exception e) {
             logger.warn("Failed to process shared documents drive: {}", actualDriveId, e);
@@ -549,12 +554,19 @@ public class OneDriveDataStore extends Microsoft365DataStore {
             try {
                 final Drive userDrive = client.getUserDrive(userId);
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Retrieved drive for user {} - Drive Name: {}, Drive ID: {}", displayName, userDrive.getName(),
-                            userDrive.getId());
+                    logger.debug("Retrieved drive for user {} - Drive Name: {}, Drive ID: {}, DriveType: {}, System: {}", displayName,
+                            userDrive.getName(), userDrive.getId(), userDrive.getDriveType(), isSystemLibrary(userDrive));
                 }
 
-                getDriveItemsInDrive(client, userDrive.getId(), item -> executorService.execute(() -> processDriveItem(dataConfig, callback,
-                        configMap, paramMap, scriptMap, defaultDataMap, client, userDrive.getId(), item, getUserRoles(user))));
+                if (Microsoft365Constants.DOCUMENT_LIBRARY.equals(userDrive.getDriveType())
+                        && (!isIgnoreSystemLibraries(paramMap) || !isSystemLibrary(userDrive))) {
+                    getDriveItemsInDrive(client, userDrive.getId(),
+                            item -> executorService.execute(() -> processDriveItem(dataConfig, callback, configMap, paramMap, scriptMap,
+                                    defaultDataMap, client, userDrive.getId(), item, getUserRoles(user))));
+                } else if (logger.isDebugEnabled()) {
+                    logger.debug("Skipping user drive: {} - Type: {}, System: {}", userDrive.getName(), userDrive.getDriveType(),
+                            isSystemLibrary(userDrive));
+                }
 
                 if (logger.isDebugEnabled()) {
                     logger.debug("Successfully initiated processing for user {}'s drive", displayName);
@@ -605,12 +617,19 @@ public class OneDriveDataStore extends Microsoft365DataStore {
             try {
                 final Drive groupDrive = client.getGroupDrive(groupId);
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Retrieved drive for group {} - Drive Name: {}, Drive ID: {}", displayName, groupDrive.getName(),
-                            groupDrive.getId());
+                    logger.debug("Retrieved drive for group {} - Drive Name: {}, Drive ID: {}, DriveType: {}, System: {}", displayName,
+                            groupDrive.getName(), groupDrive.getId(), groupDrive.getDriveType(), isSystemLibrary(groupDrive));
                 }
 
-                getDriveItemsInDrive(client, groupDrive.getId(), item -> executorService.execute(() -> processDriveItem(dataConfig,
-                        callback, configMap, paramMap, scriptMap, defaultDataMap, client, groupDrive.getId(), item, getGroupRoles(group))));
+                if (Microsoft365Constants.DOCUMENT_LIBRARY.equals(groupDrive.getDriveType())
+                        && (!isIgnoreSystemLibraries(paramMap) || !isSystemLibrary(groupDrive))) {
+                    getDriveItemsInDrive(client, groupDrive.getId(),
+                            item -> executorService.execute(() -> processDriveItem(dataConfig, callback, configMap, paramMap, scriptMap,
+                                    defaultDataMap, client, groupDrive.getId(), item, getGroupRoles(group))));
+                } else if (logger.isDebugEnabled()) {
+                    logger.debug("Skipping group drive: {} - Type: {}, System: {}", groupDrive.getName(), groupDrive.getDriveType(),
+                            isSystemLibrary(groupDrive));
+                }
 
                 if (logger.isDebugEnabled()) {
                     logger.debug("Successfully initiated processing for group {}'s drive", displayName);
@@ -694,7 +713,7 @@ public class OneDriveDataStore extends Microsoft365DataStore {
             final Map<String, Object> resultMap = new LinkedHashMap<>(paramMap.asMap());
             final Map<String, Object> filesMap = new HashMap<>();
 
-            long maxContentLength = ((Long) configMap.get(MAX_CONTENT_LENGTH));
+            long maxContentLength = (Long) configMap.get(MAX_CONTENT_LENGTH);
             if (maxContentLength < 0) {
                 try {
                     final ContentLengthHelper contentLengthHelper = ComponentUtil.getComponent("contentLengthHelper");
@@ -841,31 +860,6 @@ public class OneDriveDataStore extends Microsoft365DataStore {
     }
 
     /**
-     * Gets the user email from a permission.
-     *
-     * @param permission The permission.
-     * @return The user email.
-     */
-    protected String getUserEmail(final Permission permission) {
-        if (permission.getGrantedToV2() != null && permission.getGrantedToV2().getUser() != null) {
-            final var user = permission.getGrantedToV2().getUser();
-
-            // In Microsoft Graph SDK v6, Identity object has id and displayName properties
-            // The id is often in email format for user identities
-            // Check if the id looks like an email address
-            if ((user.getId() != null && !user.getId().isEmpty()) && user.getId().contains("@")) {
-                return user.getId();
-            }
-
-            // Fallback to displayName if available
-            if (user.getDisplayName() != null && !user.getDisplayName().isEmpty()) {
-                return user.getDisplayName();
-            }
-        }
-        return null;
-    }
-
-    /**
      * Gets the URL for a drive item.
      *
      * @param configMap The configuration map.
@@ -914,7 +908,7 @@ public class OneDriveDataStore extends Microsoft365DataStore {
             return s;
         }
         try {
-            return URLEncoder.encode(s, Constants.UTF_8).replace("+", "%20");
+            return URLEncoder.encode(s, CoreLibConstants.UTF_8).replace("+", "%20");
         } catch (final UnsupportedEncodingException e) {
             // ignore
             return s;
@@ -933,21 +927,43 @@ public class OneDriveDataStore extends Microsoft365DataStore {
      */
     protected String getDriveItemContents(final Microsoft365Client client, final String driveId, final DriveItem item,
             final long maxContentLength, final boolean ignoreError) {
-        // Check if this is a ListAttachment virtual item
-        if (item.getAdditionalData() != null && "ListAttachment".equals(item.getAdditionalData().get("sourceType"))) {
-            final String siteId = (String) item.getAdditionalData().get("siteId");
-            final String listId = (String) item.getAdditionalData().get("listId");
-            final String listItemId = (String) item.getAdditionalData().get("listItemId");
-            final String attachmentName = (String) item.getAdditionalData().get("attachmentName");
+        // Check if this is a virtual item (ListAttachment or Fields-based)
+        if (item.getAdditionalData() != null) {
+            final String sourceType = (String) item.getAdditionalData().get("sourceType");
 
-            if (siteId != null && listId != null && listItemId != null && attachmentName != null) {
-                return getListAttachmentContents(client, siteId, listId, listItemId, attachmentName, maxContentLength, ignoreError);
+            if ("ListAttachment".equals(sourceType)) {
+                // Legacy ListAttachment handling
+                final String siteId = (String) item.getAdditionalData().get("siteId");
+                final String listId = (String) item.getAdditionalData().get("listId");
+                final String listItemId = (String) item.getAdditionalData().get("listItemId");
+                final String attachmentName = (String) item.getAdditionalData().get("attachmentName");
+
+                if (siteId != null && listId != null && listItemId != null && attachmentName != null) {
+                    return getListAttachmentContents(client, siteId, listId, listItemId, attachmentName, maxContentLength, ignoreError);
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Missing required metadata for ListAttachment: siteId={}, listId={}, listItemId={}, attachmentName={}",
+                            siteId, listId, listItemId, attachmentName);
+                }
+                return StringUtil.EMPTY;
             }
-            if (logger.isDebugEnabled()) {
-                logger.debug("Missing required metadata for ListAttachment: siteId={}, listId={}, listItemId={}, attachmentName={}", siteId,
-                        listId, listItemId, attachmentName);
+
+            if ("Fields".equals(sourceType)) {
+                // Fields-based attachment handling - use the same method as ListAttachment
+                final String siteId = (String) item.getAdditionalData().get("siteId");
+                final String listId = (String) item.getAdditionalData().get("listId");
+                final String listItemId = (String) item.getAdditionalData().get("listItemId");
+                final String attachmentName = (String) item.getAdditionalData().get("attachmentName");
+
+                if (siteId != null && listId != null && listItemId != null && attachmentName != null) {
+                    return getListAttachmentContents(client, siteId, listId, listItemId, attachmentName, maxContentLength, ignoreError);
+                }
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Missing required metadata for Fields attachment: siteId={}, listId={}, listItemId={}, attachmentName={}",
+                            siteId, listId, listItemId, attachmentName);
+                }
+                return StringUtil.EMPTY;
             }
-            return StringUtil.EMPTY;
         }
 
         // Original DriveItem processing
@@ -1018,7 +1034,7 @@ public class OneDriveDataStore extends Microsoft365DataStore {
                 response.getValue().forEach(child -> getDriveItemChildren(client, driveId, consumer, child));
 
                 // Check if there's a next page
-                if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+                if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                     // No more pages, exit loop
                     break;
                 }
@@ -1158,17 +1174,25 @@ public class OneDriveDataStore extends Microsoft365DataStore {
         // Get all lists in the site
         client.getSiteLists(site.getId(), list -> {
             final boolean targetType = isTargetListType(configMap, list);
+            final boolean systemList = isSystemList(list);
+            final boolean ignoreSystem = isIgnoreSystemLists(paramMap);
 
             if (logger.isDebugEnabled()) {
-                final String template =
-                        (list.getList() != null && list.getList().getTemplate() != null) ? list.getList().getTemplate() : "unknown";
-                logger.debug("Evaluating list: {} (ID: {}, Template: {}) - TargetType: {}", list.getDisplayName(), list.getId(), template,
-                        targetType);
+                logger.debug("Evaluating list: {} (ID: {}, Template: {}) - TargetType: {}, SystemList: {}, IgnoreSystem: {}",
+                        list.getDisplayName(), list.getId(), getListTemplateType(list), targetType, systemList, ignoreSystem);
             }
 
             if (!targetType) {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Skipping list {} - doesn't match template filter", list.getDisplayName());
+                }
+                return;
+            }
+
+            if (ignoreSystem && systemList) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Skipping system list {} (ID: {}) because ignore_system_lists is enabled", list.getDisplayName(),
+                            list.getId());
                 }
                 return;
             }
@@ -1255,10 +1279,58 @@ public class OneDriveDataStore extends Microsoft365DataStore {
             logger.debug("Calling processDriveItem for list attachment: {} with {} roles", virtualAttachment.getName(), roles.size());
         }
 
-        // Process as a regular drive item using the site ID as driveId
+        // Extract the correct drive ID from the virtual attachment's parentReference
+        String driveId = null;
+        if (virtualAttachment.getParentReference() != null) {
+            driveId = virtualAttachment.getParentReference().getDriveId();
+        }
+
+        // For Fields-based attachments, use a placeholder drive ID if none exists
+        if (driveId == null) {
+            final String sourceType = (String) virtualAttachment.getAdditionalData().get("sourceType");
+            if (!"Fields".equals(sourceType)) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("No drive ID found in virtual attachment parentReference for: {} - cannot process as drive item",
+                            virtualAttachment.getName());
+                }
+                return;
+            }
+            // Use the site ID as a placeholder drive ID for Fields-based attachments
+            driveId = site.getId();
+            if (logger.isDebugEnabled()) {
+                logger.debug("Using site ID as placeholder drive ID for Fields-based attachment: {} (driveId={})",
+                        virtualAttachment.getName(), driveId);
+            }
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Validating drive ID: {} for list attachment: {} in list: {} for item: {}", driveId, virtualAttachment.getName(),
+                    list.getName(), item.getName());
+        }
+        if (Microsoft365Constants.DOCUMENT_LIBRARY.equals(getListTemplateType(list)) && driveId != null) {
+            try {
+                final Drive drive = client.getDrive(driveId);
+                if (!isIgnoreSystemLibraries(paramMap) || !isSystemLibrary(drive)) {
+                    if (logger.isDebugEnabled()) {
+                        logger.debug("Skipping system library {} (ID: {}) because ignore_system_libraries is enabled", drive.getName(),
+                                drive.getId());
+                    }
+                    return;
+                }
+            } catch (final Exception e) {
+                logger.warn("Failed to validate drive ID {} for attachment: {}}", driveId, virtualAttachment.getName(), e);
+                return;
+            }
+        }
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Processing virtual attachment as drive item with drive ID: {} for attachment: {}", driveId,
+                    virtualAttachment.getName());
+        }
+
+        // Process as a regular drive item using the correct drive ID from parentReference
         // This will trigger the full indexing pipeline
-        processDriveItem(dataConfig, callback, configMap, paramMap, scriptMap, defaultDataMap, client, site.getId(), virtualAttachment,
-                roles);
+        processDriveItem(dataConfig, callback, configMap, paramMap, scriptMap, defaultDataMap, client, driveId, virtualAttachment, roles);
 
         if (logger.isDebugEnabled()) {
             logger.debug("Completed processing list attachment: {} for item: {}", virtualAttachment.getName(), item.getId());
@@ -1313,19 +1385,16 @@ public class OneDriveDataStore extends Microsoft365DataStore {
             return true;
         }
 
-        if (list.getList() != null && list.getList().getTemplate() != null) {
-            final String template = list.getList().getTemplate();
-            if (logger.isDebugEnabled()) {
-                logger.debug("List {} has template type: {} : {}", list.getDisplayName(), template, templateTypes);
-            }
-            for (final String targetTemplate : templateTypes) {
-                if (template.equals(targetTemplate)) {
-                    return true;
-                }
-            }
-            return false;
+        final String template = getListTemplateType(list);
+        if (logger.isDebugEnabled()) {
+            logger.debug("List {} has template type: {} : {}", list.getDisplayName(), template, templateTypes);
         }
-        return true;
+        for (final String targetTemplate : templateTypes) {
+            if (template.equals(targetTemplate)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/ds/ms365/SharePointListDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/ms365/SharePointListDataStore.java
@@ -71,8 +71,6 @@ public class SharePointListDataStore extends Microsoft365DataStore {
     protected static final String NUMBER_OF_THREADS = "number_of_threads";
     /** The parameter name for default permissions. */
     protected static final String DEFAULT_PERMISSIONS = "default_permissions";
-    /** The parameter name for ignoring system lists. */
-    protected static final String IGNORE_SYSTEM_LISTS = "ignore_system_lists";
     /** The parameter name for ignoring errors. */
     protected static final String IGNORE_ERROR = "ignore_error";
     /** The parameter name for the include pattern. */
@@ -308,14 +306,14 @@ public class SharePointListDataStore extends Microsoft365DataStore {
             final Microsoft365Client client, final Site site, final com.microsoft.graph.models.List list, final ListItem item) {
 
         final String listTemplate;
-        if ((list.getList() == null) || (list.getList().getTemplate() == null)) {
+        if (list.getList() == null || list.getList().getTemplate() == null) {
             logger.warn("List template type is unknown for list: {} (ID: {}) - skipping item ID: {}", list.getDisplayName(), list.getId(),
                     item.getId());
             return;
         }
         listTemplate = list.getList().getTemplate();
 
-        if (!"genericList".equals(listTemplate)) {
+        if (!Microsoft365Constants.GENERIC_LIST.equals(listTemplate)) {
             if (logger.isDebugEnabled()) {
                 logger.debug("Skipping non-generic list item - List: {} (ID: {}, Template: {}), Item ID: {}", list.getDisplayName(),
                         list.getId(), listTemplate, item.getId());
@@ -673,37 +671,6 @@ public class SharePointListDataStore extends Microsoft365DataStore {
     }
 
     /**
-     * Checks if the list is a system list.
-     *
-     * @param list the SharePoint list to check
-     * @return true if the list is a system list, false otherwise
-     */
-    protected boolean isSystemList(final com.microsoft.graph.models.List list) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Checking if list is system list - Name: {}, ID: {}, Template: {}, WebUrl: {}", list.getDisplayName(),
-                    list.getId(), list.getList() != null ? list.getList().getTemplate() : "unknown", list.getWebUrl());
-        }
-
-        // Use URL-based detection for better reliability when available
-        if (list.getWebUrl() != null) {
-            final String url = list.getWebUrl().toLowerCase();
-            return url.contains("/_catalogs/") || url.contains("/lists/userinformationlist") || url.contains("/lists/workflowtasks")
-                    || url.contains("/lists/accessrequests") || url.contains("/sitepages/") || url.contains("/siteassets/")
-                    || url.contains("/lists/masterpage") || url.contains("/lists/stylelibrary") || url.contains("/lists/formtemplates")
-                    || url.contains("/_layouts/") || url.contains("/workflowhistory") || url.contains("/_private/");
-        }
-
-        // Fallback to name-based detection when URL is not available
-        if (list.getDisplayName() == null) {
-            return false;
-        }
-        final String name = list.getDisplayName().toLowerCase();
-        return name.contains("master page") || name.contains("style library") || name.contains("_catalogs") || name.contains("workflow")
-                || name.contains("user information") || name.contains("access requests") || name.startsWith("_")
-                || name.contains("form templates");
-    }
-
-    /**
      * Checks if the list item should be crawled based on include/exclude patterns.
      *
      * @param paramMap the data store parameters
@@ -742,26 +709,6 @@ public class SharePointListDataStore extends Microsoft365DataStore {
         }
 
         return true;
-    }
-
-    /**
-     * Checks if errors should be ignored during crawling.
-     *
-     * @param paramMap the data store parameters
-     * @return true if errors should be ignored, false otherwise
-     */
-    protected boolean isIgnoreError(final DataStoreParams paramMap) {
-        return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(IGNORE_ERROR, Constants.FALSE));
-    }
-
-    /**
-     * Checks if system lists should be ignored during crawling.
-     *
-     * @param paramMap the data store parameters
-     * @return true if system lists should be ignored, false otherwise
-     */
-    protected boolean isIgnoreSystemLists(final DataStoreParams paramMap) {
-        return Constants.TRUE.equalsIgnoreCase(paramMap.getAsString(IGNORE_SYSTEM_LISTS, Constants.TRUE));
     }
 
     /**

--- a/src/main/java/org/codelibs/fess/ds/ms365/TeamsDataStore.java
+++ b/src/main/java/org/codelibs/fess/ds/ms365/TeamsDataStore.java
@@ -258,10 +258,8 @@ public class TeamsDataStore extends Microsoft365DataStore {
                     logger.debug("Successfully processed consolidated chat message for chat: {} with {} individual messages", chatId,
                             msgList.size());
                 }
-            } else {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("No messages found for chat: {}", chatId);
-                }
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("No messages found for chat: {}", chatId);
             }
         } else if (logger.isDebugEnabled()) {
             logger.debug("No specific chat ID configured - skipping chat message processing");
@@ -721,10 +719,9 @@ public class TeamsDataStore extends Microsoft365DataStore {
      * @return true if the message is a system event and should be ignored, false otherwise.
      */
     protected boolean isSystemEvent(final Map<String, Object> configMap, final ChatMessage message) {
-        if (((Boolean) configMap.get(IGNORE_SYSTEM_EVENTS))) {
-            if (message.getBody() != null && "<systemEventMessage/>".equals(message.getBody().getContent())) {
-                return true;
-            }
+        if ((Boolean) configMap.get(IGNORE_SYSTEM_EVENTS) && message.getBody() != null
+                && "<systemEventMessage/>".equals(message.getBody().getContent())) {
+            return true;
         }
         return false;
     }

--- a/src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java
+++ b/src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java
@@ -15,14 +15,6 @@
  */
 package org.codelibs.fess.ds.ms365.client;
 
-import static org.codelibs.fess.ds.ms365.Microsoft365Constants.ATTACHMENT_NAME_KEY;
-import static org.codelibs.fess.ds.ms365.Microsoft365Constants.LIST_ATTACHMENT_SOURCE_TYPE;
-import static org.codelibs.fess.ds.ms365.Microsoft365Constants.LIST_ID_KEY;
-import static org.codelibs.fess.ds.ms365.Microsoft365Constants.LIST_ITEM_ID_KEY;
-import static org.codelibs.fess.ds.ms365.Microsoft365Constants.LIST_ITEM_TITLE_KEY;
-import static org.codelibs.fess.ds.ms365.Microsoft365Constants.SITE_ID_KEY;
-import static org.codelibs.fess.ds.ms365.Microsoft365Constants.SOURCE_TYPE_KEY;
-
 import java.io.Closeable;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -39,8 +31,8 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.codelibs.core.CoreLibConstants;
 import org.codelibs.core.lang.StringUtil;
-import org.codelibs.fess.Constants;
 import org.codelibs.fess.crawler.exception.CrawlingAccessException;
 import org.codelibs.fess.entity.DataStoreParams;
 import org.codelibs.fess.exception.DataStoreCrawlingException;
@@ -155,14 +147,14 @@ public class Microsoft365Client implements Closeable {
 
         try {
             // Add multi-tenant authentication support for Azure Identity v1.16.3
-            final ClientSecretCredential clientSecretCredential = new ClientSecretCredentialBuilder().clientId(clientId)
+            final ClientSecretCredential credential = new ClientSecretCredentialBuilder().clientId(clientId)
                     .clientSecret(clientSecret)
                     .tenantId(tenant)
                     .additionallyAllowedTenants("*") // Allow all tenants for backward compatibility
                     .build();
 
             // Initialize GraphServiceClient with new v6 API
-            client = new GraphServiceClient(clientSecretCredential);
+            client = new GraphServiceClient(credential);
         } catch (final Exception e) {
             throw new DataStoreException("Failed to create a client.", e);
         }
@@ -424,7 +416,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -468,7 +460,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -500,7 +492,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -565,7 +557,7 @@ public class Microsoft365Client implements Closeable {
             sections.addAll(response.getValue());
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -607,7 +599,7 @@ public class Microsoft365Client implements Closeable {
             pages.addAll(response.getValue());
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -741,7 +733,7 @@ public class Microsoft365Client implements Closeable {
                 sites.forEach(consumer::accept);
 
                 // Check if there's a next page
-                if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+                if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                     // No more pages, exit loop
                     if (logger.isDebugEnabled()) {
                         logger.debug("Site pagination completed - processed {} pages with total {} sites", pageCount, totalSites);
@@ -807,7 +799,7 @@ public class Microsoft365Client implements Closeable {
                 lists.forEach(consumer::accept);
 
                 // Check if there's a next page
-                if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+                if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                     // No more pages, exit loop
                     if (logger.isDebugEnabled()) {
                         logger.debug("List pagination completed for site {} - processed {} pages with total {} lists", siteId, pageCount,
@@ -899,7 +891,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -978,7 +970,7 @@ public class Microsoft365Client implements Closeable {
                 response.getValue().forEach(child -> getDriveItemChildren(driveId, consumer, child));
 
                 // Check if there's a next page
-                if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+                if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                     // No more pages, exit loop
                     break;
                 }
@@ -1039,7 +1031,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -1063,7 +1055,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -1149,7 +1141,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(filter);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -1179,7 +1171,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -1236,7 +1228,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -1266,7 +1258,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -1300,7 +1292,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -1324,7 +1316,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -1382,7 +1374,7 @@ public class Microsoft365Client implements Closeable {
                 messages.forEach(consumer::accept);
 
                 // Check if there's a next page
-                if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+                if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                     // No more pages, exit loop
                     if (logger.isDebugEnabled()) {
                         logger.debug("Chat message pagination completed for chat {} - processed {} pages with total {} messages", chatId,
@@ -1420,7 +1412,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -1472,7 +1464,7 @@ public class Microsoft365Client implements Closeable {
             response.getValue().forEach(consumer::accept);
 
             // Check if there's a next page
-            if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+            if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                 // No more pages, exit loop
                 break;
             }
@@ -1493,7 +1485,7 @@ public class Microsoft365Client implements Closeable {
         }
         // https://learn.microsoft.com/en-us/answers/questions/1072289/download-directly-chat-attachment-using-contenturl
         final String id = "u!" + Base64.getUrlEncoder()
-                .encodeToString(attachment.getContentUrl().getBytes(Constants.CHARSET_UTF_8))
+                .encodeToString(attachment.getContentUrl().getBytes(CoreLibConstants.CHARSET_UTF_8))
                 .replaceFirst("=+$", StringUtil.EMPTY)
                 .replace('/', '_')
                 .replace('+', '-');
@@ -1680,133 +1672,406 @@ public class Microsoft365Client implements Closeable {
     }
 
     /**
-     * Retrieves all attachments for a specific list item, processing each attachment with the provided consumer.
-     * Implements pagination to handle list items with many attachments.
+     * Retrieves attachments for a SharePoint list item using Microsoft Graph API.
+     * This method uses the driveItem relationship to access attachments as DriveItem objects.
      *
-     * @param siteId The ID of the SharePoint site.
-     * @param listId The ID of the SharePoint list.
-     * @param itemId The ID of the list item.
-     * @param consumer A consumer to process each Attachment object.
+     * @param siteId The SharePoint site ID
+     * @param listId The SharePoint list ID
+     * @param itemId The SharePoint list item ID
+     * @param consumer Consumer to process each attachment DriveItem
      */
     public void getListItemAttachments(final String siteId, final String listId, final String itemId, final Consumer<DriveItem> consumer) {
-        if (StringUtil.isBlank(siteId) || StringUtil.isBlank(listId) || StringUtil.isBlank(itemId)) {
-            logger.warn("siteId, listId, and itemId cannot be null or empty - Site: {}, List: {}, Item: {}", siteId, listId, itemId);
+        if (siteId == null || listId == null || itemId == null || consumer == null) {
             return;
         }
 
+        // Stage 1: Try DriveItem approach (for documentLibrary and similar templates)
+        // Stage 2: Try Attachments field approach (for genericList and other standard templates)
+        if (tryDriveItemAttachments(siteId, listId, itemId, consumer) || tryFieldsAttachments(siteId, listId, itemId, consumer)) {
+            return;
+        }
+
+        // Stage 3: Fallback - no attachments found
+        logger.debug("No attachments found for list item: siteId={}, listId={}, itemId={}", siteId, listId, itemId);
+    }
+
+    /**
+     * Attempts to retrieve attachments using driveItem relationship (for document libraries).
+     *
+     * @param siteId The SharePoint site ID
+     * @param listId The SharePoint list ID
+     * @param itemId The SharePoint list item ID
+     * @param consumer Consumer to process each attachment DriveItem
+     * @return true if successful, false if this list item doesn't have driveItem
+     */
+    private boolean tryDriveItemAttachments(final String siteId, final String listId, final String itemId,
+            final Consumer<DriveItem> consumer) {
         try {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Checking for attachments in list item - Site: {}, List: {}, Item: {}", siteId, listId, itemId);
-            }
+            // First get the list item to check if it has a driveItem
+            final ListItem listItem =
+                    client.sites().bySiteId(siteId).lists().byListId(listId).items().byListItemId(itemId).get(requestConfiguration -> {
+                        requestConfiguration.queryParameters.expand = new String[] { "driveItem" };
+                    });
 
-            // Get the list item to check for attachments field
-            final ListItem listItem = getListItem(siteId, listId, itemId, true);
             if (listItem == null) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("List item {} not found in list {}", itemId, listId);
-                }
-                return;
+                logger.debug("List item not found: siteId={}, listId={}, itemId={}", siteId, listId, itemId);
+                return false;
             }
 
-            // Check if the list item has attachments
-            boolean hasAttachments = false;
-            if (listItem.getFields() != null && listItem.getFields().getAdditionalData() != null) {
-                final Object attachmentsField = listItem.getFields().getAdditionalData().get("Attachments");
-                if (attachmentsField instanceof Boolean) {
-                    hasAttachments = (Boolean) attachmentsField;
-                } else if (attachmentsField instanceof String) {
-                    hasAttachments = "true".equalsIgnoreCase((String) attachmentsField);
-                }
+            final DriveItem driveItem = listItem.getDriveItem();
+            if (driveItem == null) {
+                logger.debug("No driveItem found for list item (likely generic list): siteId={}, listId={}, itemId={}", siteId, listId,
+                        itemId);
+                return false;
             }
 
-            if (hasAttachments) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("List item {} has attachments - creating virtual DriveItem", itemId);
-                }
+            // Get the drive ID from the driveItem
+            final String driveId = driveItem.getParentReference() != null ? driveItem.getParentReference().getDriveId() : null;
 
-                // Create a virtual DriveItem for list attachment
-                // Since we can't get actual attachment details via Graph API, we create a placeholder
-                final DriveItem virtualAttachment = new DriveItem();
+            if (driveId == null) {
+                logger.debug("No drive ID found in driveItem for list item: siteId={}, listId={}, itemId={}", siteId, listId, itemId);
+                return false;
+            }
 
-                // Set basic properties with fallback values
-                virtualAttachment.setName("ListAttachment_" + itemId); // Generic name since actual filename unknown
-                virtualAttachment.setId("attachment_" + itemId); // Virtual ID
+            final String driveItemId = driveItem.getId();
+            if (driveItemId == null) {
+                logger.debug("No driveItem ID found for list item: siteId={}, listId={}, itemId={}", siteId, listId, itemId);
+                return false;
+            }
 
-                // Set timestamps from list item
-                virtualAttachment.setCreatedDateTime(listItem.getCreatedDateTime());
-                virtualAttachment.setLastModifiedDateTime(listItem.getLastModifiedDateTime());
+            // Get children (attachments) of the driveItem
+            try {
+                final DriveItemCollectionResponse childrenResponse =
+                        client.drives().byDriveId(driveId).items().byDriveItemId(driveItemId).children().get();
 
-                // Create virtual web URL pointing to list item
-                final Site site = getSite(siteId);
-                if (site != null && site.getWebUrl() != null) {
-                    final String attachmentUrl = String.format("%s/Lists/%s/DispForm.aspx?ID=%s", site.getWebUrl(), listId, itemId);
-                    virtualAttachment.setWebUrl(attachmentUrl);
-                }
+                if (childrenResponse != null && childrenResponse.getValue() != null) {
+                    for (final DriveItem attachment : childrenResponse.getValue()) {
+                        if (attachment != null) {
+                            logger.debug("Processing driveItem attachment: {}", attachment.getName());
+                            consumer.accept(attachment);
+                        }
+                    }
 
-                // Mark as attachment with additional metadata
-                final Map<String, Object> additionalData = new HashMap<>();
-                additionalData.put(SOURCE_TYPE_KEY, LIST_ATTACHMENT_SOURCE_TYPE);
-                additionalData.put(SITE_ID_KEY, siteId);
-                additionalData.put(LIST_ID_KEY, listId);
-                additionalData.put(LIST_ITEM_ID_KEY, itemId);
-                // For now, using a placeholder name since we can't get actual attachment names via Graph API
-                additionalData.put(ATTACHMENT_NAME_KEY, "attachment_" + itemId);
+                    // Handle pagination if there are more attachments
+                    String nextLink = childrenResponse.getOdataNextLink();
+                    while (nextLink != null) {
+                        final DriveItemCollectionResponse nextResponse =
+                                client.drives().byDriveId(driveId).items().byDriveItemId(driveItemId).children().withUrl(nextLink).get();
 
-                // Add list item title if available
-                if (listItem.getFields() != null && listItem.getFields().getAdditionalData() != null) {
-                    final Object titleObj = listItem.getFields().getAdditionalData().get("Title");
-                    if (titleObj != null) {
-                        additionalData.put(LIST_ITEM_TITLE_KEY, titleObj.toString());
+                        if (nextResponse != null && nextResponse.getValue() != null) {
+                            for (final DriveItem attachment : nextResponse.getValue()) {
+                                if (attachment != null) {
+                                    logger.debug("Processing paginated driveItem attachment: {}", attachment.getName());
+                                    consumer.accept(attachment);
+                                }
+                            }
+                        }
+                        nextLink = nextResponse != null ? nextResponse.getOdataNextLink() : null;
                     }
                 }
-
-                virtualAttachment.setAdditionalData(additionalData);
-
-                // Pass the virtual attachment to consumer
-                consumer.accept(virtualAttachment);
-
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Created virtual DriveItem for list item {} attachments", itemId);
+                return true; // Successfully processed driveItem attachments
+            } catch (final ApiException e) {
+                if (e.getResponseStatusCode() == 404) {
+                    logger.debug("No driveItem attachments found for list item: siteId={}, listId={}, itemId={}", siteId, listId, itemId);
+                } else {
+                    logger.warn("Failed to retrieve driveItem attachments for list item: siteId={}, listId={}, itemId={}", siteId, listId,
+                            itemId, e);
                 }
-            } else {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("No attachments found for list item {} in list {}", itemId, listId);
-                }
+                return true; // We successfully tried driveItem approach, even if no attachments found
             }
 
+        } catch (final ApiException e) {
+            // Handle the specific error when list item is not in a document library (doesn't have driveItem)
+            if (e.getMessage() != null
+                    && e.getMessage().contains("Cannot request driveItem for an item that is not in a document library")) {
+                logger.debug("List item is not a document library item (no driveItem available): siteId={}, listId={}, itemId={}", siteId,
+                        listId, itemId);
+                return false;
+            }
+            logger.warn("Failed to access list item for driveItem attachments: siteId={}, listId={}, itemId={}", siteId, listId, itemId, e);
+            return false;
         } catch (final Exception e) {
-            logger.warn("Failed to check attachments for list item {} in list {} on site {}: {}", itemId, listId, siteId, e.getMessage());
-            if (logger.isDebugEnabled()) {
-                logger.debug("Full exception for list item attachments check", e);
-            }
-            // Don't throw exception to avoid breaking the crawling process
+            logger.warn("Unexpected error while retrieving driveItem attachments: siteId={}, listId={}, itemId={}", siteId, listId, itemId,
+                    e);
+            return false;
         }
     }
 
     /**
-     * Retrieves the content of a specific attachment from a list item as an InputStream.
+     * Attempts to retrieve attachments using fields approach (for generic lists and other standard templates).
      *
-     * @param siteId The ID of the SharePoint site.
-     * @param listId The ID of the SharePoint list.
-     * @param itemId The ID of the list item.
-     * @param attachmentName The name of the attachment.
-     * @return An InputStream containing the attachment content.
+     * @param siteId The SharePoint site ID
+     * @param listId The SharePoint list ID
+     * @param itemId The SharePoint list item ID
+     * @param consumer Consumer to process each attachment DriveItem (created from field data)
+     * @return true if successfully processed, false if no attachments or failed
+     */
+    private boolean tryFieldsAttachments(final String siteId, final String listId, final String itemId,
+            final Consumer<DriveItem> consumer) {
+        try {
+            // Get the list item with expanded fields
+            final ListItem listItem =
+                    client.sites().bySiteId(siteId).lists().byListId(listId).items().byListItemId(itemId).get(requestConfiguration -> {
+                        requestConfiguration.queryParameters.expand = new String[] { "fields" };
+                    });
+
+            if (listItem == null) {
+                logger.debug("List item not found for fields attachment processing: siteId={}, listId={}, itemId={}", siteId, listId,
+                        itemId);
+                return false;
+            }
+
+            final com.microsoft.graph.models.FieldValueSet fieldValueSet = listItem.getFields();
+            if (fieldValueSet == null || fieldValueSet.getAdditionalData() == null) {
+                logger.debug("No fields found for list item: siteId={}, listId={}, itemId={}", siteId, listId, itemId);
+                return false;
+            }
+
+            final Map<String, Object> fields = fieldValueSet.getAdditionalData();
+
+            // Check for Attachments field (standard SharePoint field for generic lists)
+            final Object attachmentsField = fields.get("Attachments");
+            if (attachmentsField == null) {
+                logger.debug("No Attachments field found for list item: siteId={}, listId={}, itemId={}", siteId, listId, itemId);
+                return false;
+            }
+
+            // Parse attachments field value
+            if (!hasAttachments(attachmentsField)) {
+                logger.debug("Attachments field indicates no attachments for list item: siteId={}, listId={}, itemId={}", siteId, listId,
+                        itemId);
+                return true; // Successfully processed (no attachments)
+            }
+
+            // Try to get attachment details from other fields or item metadata
+            final List<String> attachmentNames = extractAttachmentNames(fields);
+            if (attachmentNames.isEmpty()) {
+                logger.debug("No attachment names found for list item with attachments: siteId={}, listId={}, itemId={}", siteId, listId,
+                        itemId);
+                return true; // Successfully processed (no attachment names available)
+            }
+
+            // Create virtual DriveItems for each attachment
+            int attachmentCount = 0;
+            for (final String attachmentName : attachmentNames) {
+                if (attachmentName != null && !attachmentName.trim().isEmpty()) {
+                    final DriveItem virtualDriveItem =
+                            createVirtualDriveItemFromFieldAttachment(attachmentName, siteId, listId, itemId, attachmentCount);
+                    attachmentCount++;
+                    if (virtualDriveItem != null) {
+                        logger.debug("Processing fields-based attachment: {}", attachmentName);
+                        consumer.accept(virtualDriveItem);
+                    }
+                }
+            }
+
+            logger.debug("Successfully processed {} field-based attachments for list item: siteId={}, listId={}, itemId={}",
+                    attachmentCount, siteId, listId, itemId);
+            return true;
+
+        } catch (final ApiException e) {
+            if (e.getResponseStatusCode() == 404) {
+                logger.debug("List item not found for fields attachment processing: siteId={}, listId={}, itemId={}", siteId, listId,
+                        itemId);
+            } else {
+                logger.info("Failed to retrieve fields-based attachments for list item: siteId={}, listId={}, itemId={}", siteId, listId,
+                        itemId, e);
+            }
+            return false;
+        } catch (final Exception e) {
+            logger.info("Unexpected error while retrieving fields-based attachments: siteId={}, listId={}, itemId={}", siteId, listId,
+                    itemId, e);
+            return false;
+        }
+    }
+
+    /**
+     * Checks if the Attachments field indicates that attachments exist.
+     *
+     * @param attachmentsField The value of the Attachments field
+     * @return true if attachments exist, false otherwise
+     */
+    private boolean hasAttachments(final Object attachmentsField) {
+        if (attachmentsField == null) {
+            return false;
+        }
+
+        final String attachmentsValue = attachmentsField.toString().trim();
+
+        // SharePoint Attachments field typically contains:
+        // "1" or "true" = has attachments
+        // "0" or "false" = no attachments
+        // Or actual attachment filenames
+        return "1".equals(attachmentsValue) || "true".equalsIgnoreCase(attachmentsValue)
+                || !attachmentsValue.isEmpty() && !"0".equals(attachmentsValue) && !"false".equalsIgnoreCase(attachmentsValue);
+    }
+
+    /**
+     * Extracts attachment names from SharePoint list item fields.
+     * This is a best-effort approach as different list templates may store attachment info differently.
+     *
+     * @param fields The field values map
+     * @return List of attachment names (may be empty if names cannot be determined)
+     */
+    private List<String> extractAttachmentNames(final Map<String, Object> fields) {
+        final List<String> attachmentNames = new ArrayList<>();
+
+        // Try various field patterns that might contain attachment names
+        final String[] attachmentFields = { "AttachmentFiles", "Attachments", "FileRef", "FileLeafRef", "File_x0020_Name" };
+
+        for (final String fieldName : attachmentFields) {
+            final Object fieldValue = fields.get(fieldName);
+            if (fieldValue != null) {
+                final String value = fieldValue.toString().trim();
+                if (!value.isEmpty() && !"0".equals(value) && !"false".equalsIgnoreCase(value)) {
+                    // If it looks like a filename or list of filenames, add them
+                    if (value.contains(".") || value.contains(";") || value.contains(",")) {
+                        // Split potential multiple filenames
+                        final String[] names = value.split("[;,]");
+                        for (final String name : names) {
+                            final String cleanName = name.trim();
+                            if (!cleanName.isEmpty() && cleanName.contains(".")) {
+                                attachmentNames.add(cleanName);
+                            }
+                        }
+                    } else if (value.contains(".")) {
+                        // Single filename
+                        attachmentNames.add(value);
+                    }
+                }
+            }
+        }
+
+        // If no specific attachment names found but attachments exist, create generic names
+        if (attachmentNames.isEmpty()) {
+            final Object attachmentsField = fields.get("Attachments");
+            if (hasAttachments(attachmentsField)) {
+                // Create a generic attachment entry
+                attachmentNames.add("attachment.bin");
+            }
+        }
+
+        return attachmentNames;
+    }
+
+    /**
+     * Creates a virtual DriveItem from SharePoint list field-based attachment information.
+     *
+     * @param attachmentName The name of the attachment
+     * @param siteId The SharePoint site ID
+     * @param listId The SharePoint list ID
+     * @param listItemId The SharePoint list item ID
+     * @param attachmentIndex The index of this attachment (for unique IDs)
+     * @return Virtual DriveItem representing the attachment
+     */
+    private DriveItem createVirtualDriveItemFromFieldAttachment(final String attachmentName, final String siteId, final String listId,
+            final String listItemId, final int attachmentIndex) {
+        if (attachmentName == null || attachmentName.trim().isEmpty()) {
+            return null;
+        }
+
+        try {
+            final DriveItem virtualDriveItem = new DriveItem();
+
+            // Generate a unique ID for the virtual attachment
+            final String virtualId = String.format("field-attachment-%s-%s-%s-%d", siteId, listId, listItemId, attachmentIndex);
+            virtualDriveItem.setId(virtualId);
+            virtualDriveItem.setName(attachmentName);
+
+            // Create a File object to indicate this is a file
+            final com.microsoft.graph.models.File file = new com.microsoft.graph.models.File();
+            file.setMimeType("application/octet-stream"); // Default mime type, will be detected during processing
+            virtualDriveItem.setFile(file);
+
+            // Add metadata to identify this as a fields-based attachment
+            final Map<String, Object> additionalData = new HashMap<>();
+            additionalData.put("sourceType", "Fields");
+            additionalData.put("siteId", siteId);
+            additionalData.put("listId", listId);
+            additionalData.put("listItemId", listItemId);
+            additionalData.put("attachmentName", attachmentName);
+            additionalData.put("attachmentIndex", attachmentIndex);
+            virtualDriveItem.setAdditionalData(additionalData);
+
+            // Create a web URL for the attachment (approximation)
+            final String webUrl = String.format("https://graph.microsoft.com/v1.0/sites/%s/lists/%s/items/%s/attachments/%s", siteId,
+                    listId, listItemId, attachmentName);
+            virtualDriveItem.setWebUrl(webUrl);
+
+            if (logger.isDebugEnabled()) {
+                logger.debug("Created virtual DriveItem for field-based attachment: {} (ID: {})", attachmentName, virtualId);
+            }
+
+            return virtualDriveItem;
+
+        } catch (final Exception e) {
+            logger.warn("Failed to create virtual DriveItem from field attachment: {}", attachmentName, e);
+            return null;
+        }
+    }
+
+    /**
+     * Retrieves the content of a specific SharePoint list item attachment using Microsoft Graph API.
+     * This method accesses the attachment through the driveItem relationship.
+     *
+     * @param siteId The SharePoint site ID
+     * @param listId The SharePoint list ID
+     * @param itemId The SharePoint list item ID
+     * @param attachmentName The name of the attachment to retrieve
+     * @return InputStream containing the attachment content, or null if not found
      */
     public InputStream getListItemAttachmentContent(final String siteId, final String listId, final String itemId,
             final String attachmentName) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Attempting to get content for list attachment {} in item {} of list {} on site {}", attachmentName, itemId,
-                    listId, siteId);
+        if (siteId == null || listId == null || itemId == null || attachmentName == null) {
+            return null;
         }
 
-        // For now, return placeholder content as Microsoft Graph API doesn't provide direct access to list attachments
-        // In a full implementation, this would use SharePoint REST API or other approaches
-        final String placeholderContent = String.format(
-                "List Attachment Placeholder\n" + "Site ID: %s\n" + "List ID: %s\n" + "Item ID: %s\n" + "Attachment: %s\n"
-                        + "Note: Actual content retrieval requires SharePoint REST API integration.",
-                siteId, listId, itemId, attachmentName);
+        try {
+            // First get the list item to access its driveItem
+            final ListItem listItem =
+                    client.sites().bySiteId(siteId).lists().byListId(listId).items().byListItemId(itemId).get(requestConfiguration -> {
+                        requestConfiguration.queryParameters.expand = new String[] { "driveItem" };
+                    });
 
-        return new java.io.ByteArrayInputStream(placeholderContent.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            if (listItem == null || listItem.getDriveItem() == null) {
+                logger.debug("List item or driveItem not found: siteId={}, listId={}, itemId={}", siteId, listId, itemId);
+                return null;
+            }
+
+            final DriveItem driveItem = listItem.getDriveItem();
+            final String driveId = driveItem.getParentReference() != null ? driveItem.getParentReference().getDriveId() : null;
+
+            if (driveId == null || driveItem.getId() == null) {
+                logger.debug("Drive ID or driveItem ID not found: siteId={}, listId={}, itemId={}", siteId, listId, itemId);
+                return null;
+            }
+
+            // Search for the attachment by name in the driveItem children
+            final DriveItemCollectionResponse childrenResponse =
+                    client.drives().byDriveId(driveId).items().byDriveItemId(driveItem.getId()).children().get();
+
+            if (childrenResponse != null && childrenResponse.getValue() != null) {
+                for (final DriveItem attachment : childrenResponse.getValue()) {
+                    if (attachment != null && attachmentName.equals(attachment.getName())) {
+                        // Found the attachment, get its content
+                        return client.drives().byDriveId(driveId).items().byDriveItemId(attachment.getId()).content().get();
+                    }
+                }
+            }
+
+            logger.debug("Attachment not found: siteId={}, listId={}, itemId={}, attachmentName={}", siteId, listId, itemId,
+                    attachmentName);
+            return null;
+
+        } catch (final ApiException e) {
+            logger.warn("Failed to retrieve attachment content: siteId={}, listId={}, itemId={}, attachmentName={}", siteId, listId, itemId,
+                    attachmentName, e);
+            return null;
+        } catch (final Exception e) {
+            logger.warn("Unexpected error retrieving attachment content: siteId={}, listId={}, itemId={}, attachmentName={}", siteId,
+                    listId, itemId, attachmentName, e);
+            return null;
+        }
     }
 
     /**
@@ -1823,7 +2088,7 @@ public class Microsoft365Client implements Closeable {
                 response.getValue().forEach(consumer::accept);
 
                 // Check if there's a next page
-                if ((response.getOdataNextLink() == null) || response.getOdataNextLink().isEmpty()) {
+                if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
                     // No more pages, exit loop
                     break;
                 }

--- a/src/test/java/org/codelibs/fess/ds/ms365/OneDriveDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/ms365/OneDriveDataStoreTest.java
@@ -20,13 +20,17 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.codelibs.fess.crawler.filter.UrlFilter;
 import org.codelibs.fess.ds.callback.IndexUpdateCallback;
 import org.codelibs.fess.entity.DataStoreParams;
 import org.codelibs.fess.util.ComponentUtil;
 import org.dbflute.utflute.lastaflute.LastaFluteTestCase;
 
 import com.microsoft.graph.models.DriveItem;
+import com.microsoft.graph.models.Identity;
 import com.microsoft.graph.models.ItemReference;
+import com.microsoft.graph.models.Permission;
+import com.microsoft.graph.models.SharePointIdentitySet;
 
 public class OneDriveDataStoreTest extends LastaFluteTestCase {
 
@@ -61,6 +65,10 @@ public class OneDriveDataStoreTest extends LastaFluteTestCase {
         super.tearDown();
     }
 
+    public void test_getName() {
+        assertEquals("OneDriveDataStore", dataStore.getName());
+    }
+
     public void test_getUrl() {
         Map<String, Object> configMap = new HashMap<>();
         DataStoreParams paramMap = new DataStoreParams();
@@ -83,8 +91,257 @@ public class OneDriveDataStoreTest extends LastaFluteTestCase {
                 dataStore.getUrl(configMap, paramMap, item));
     }
 
+    public void test_getUrlFilter() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Test with no include/exclude patterns - should return a UrlFilter instance but behavior depends on implementation
+        try {
+            UrlFilter filter = dataStore.getUrlFilter(paramMap);
+            // UrlFilter is created by ComponentUtil.getComponent() so it may throw exception in test environment
+            // This is expected behavior in isolated test environment
+            assertNotNull(filter);
+        } catch (Exception e) {
+            // Expected in test environment where ComponentUtil dependencies are not available
+            assertTrue("Expected ComponentNotFoundException or similar",
+                    e.getMessage().contains("ComponentNotFound") || e.getMessage().contains("Component"));
+        }
+    }
+
+    public void test_isSharedDocumentsDriveCrawler() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        assertTrue(dataStore.isSharedDocumentsDriveCrawler(paramMap)); // default is true based on implementation
+
+        paramMap.put(OneDriveDataStore.SHARED_DOCUMENTS_DRIVE_CRAWLER, "false");
+        assertFalse(dataStore.isSharedDocumentsDriveCrawler(paramMap));
+
+        paramMap.put(OneDriveDataStore.SHARED_DOCUMENTS_DRIVE_CRAWLER, "true");
+        assertTrue(dataStore.isSharedDocumentsDriveCrawler(paramMap));
+    }
+
+    public void test_isUserDriveCrawler() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        assertTrue(dataStore.isUserDriveCrawler(paramMap)); // default is true
+
+        paramMap.put(OneDriveDataStore.USER_DRIVE_CRAWLER, "false");
+        assertFalse(dataStore.isUserDriveCrawler(paramMap));
+
+        paramMap.put(OneDriveDataStore.USER_DRIVE_CRAWLER, "true");
+        assertTrue(dataStore.isUserDriveCrawler(paramMap));
+    }
+
+    public void test_isGroupDriveCrawler() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        assertTrue(dataStore.isGroupDriveCrawler(paramMap)); // default is true
+
+        paramMap.put(OneDriveDataStore.GROUP_DRIVE_CRAWLER, "false");
+        assertFalse(dataStore.isGroupDriveCrawler(paramMap));
+
+        paramMap.put(OneDriveDataStore.GROUP_DRIVE_CRAWLER, "true");
+        assertTrue(dataStore.isGroupDriveCrawler(paramMap));
+    }
+
+    public void test_isListAttachmentsCrawler() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        assertFalse(dataStore.isListAttachmentsCrawler(paramMap)); // default is false
+
+        paramMap.put(OneDriveDataStore.LIST_ATTACHMENTS_CRAWLER, "false");
+        assertFalse(dataStore.isListAttachmentsCrawler(paramMap));
+
+        paramMap.put(OneDriveDataStore.LIST_ATTACHMENTS_CRAWLER, "true");
+        assertTrue(dataStore.isListAttachmentsCrawler(paramMap));
+    }
+
+    public void test_isIgnoreFolder() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        assertTrue(dataStore.isIgnoreFolder(paramMap)); // default is true
+
+        paramMap.put(OneDriveDataStore.IGNORE_FOLDER, "false");
+        assertFalse(dataStore.isIgnoreFolder(paramMap));
+
+        paramMap.put(OneDriveDataStore.IGNORE_FOLDER, "true");
+        assertTrue(dataStore.isIgnoreFolder(paramMap));
+    }
+
+    public void test_isIgnoreError() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        assertFalse(dataStore.isIgnoreError(paramMap)); // default is false for consistency
+
+        paramMap.put(OneDriveDataStore.IGNORE_ERROR, "false");
+        assertFalse(dataStore.isIgnoreError(paramMap));
+
+        paramMap.put(OneDriveDataStore.IGNORE_ERROR, "true");
+        assertTrue(dataStore.isIgnoreError(paramMap));
+    }
+
+    public void test_getMaxSize() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Test default value
+        assertEquals(OneDriveDataStore.DEFAULT_MAX_SIZE, dataStore.getMaxSize(paramMap));
+
+        // Test custom value
+        paramMap.put(OneDriveDataStore.MAX_CONTENT_LENGTH, "1024");
+        assertEquals(1024L, dataStore.getMaxSize(paramMap));
+
+        // Test invalid value (non-numeric)
+        paramMap.put(OneDriveDataStore.MAX_CONTENT_LENGTH, "invalid");
+        assertEquals(OneDriveDataStore.DEFAULT_MAX_SIZE, dataStore.getMaxSize(paramMap));
+    }
+
+    public void test_getSupportedMimeTypes() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Test default (should return ".*" as array)
+        String[] mimeTypes = dataStore.getSupportedMimeTypes(paramMap);
+        assertNotNull(mimeTypes);
+        assertEquals(1, mimeTypes.length);
+        assertEquals(".*", mimeTypes[0]);
+
+        // Test single mime type
+        paramMap.put(OneDriveDataStore.SUPPORTED_MIMETYPES, "text/plain");
+        mimeTypes = dataStore.getSupportedMimeTypes(paramMap);
+        assertNotNull(mimeTypes);
+        assertEquals(1, mimeTypes.length);
+        assertEquals("text/plain", mimeTypes[0]);
+
+        // Test multiple mime types
+        paramMap.put(OneDriveDataStore.SUPPORTED_MIMETYPES, "text/plain,application/pdf,image/jpeg");
+        mimeTypes = dataStore.getSupportedMimeTypes(paramMap);
+        assertNotNull(mimeTypes);
+        assertEquals(3, mimeTypes.length);
+        assertEquals("text/plain", mimeTypes[0]);
+        assertEquals("application/pdf", mimeTypes[1]);
+        assertEquals("image/jpeg", mimeTypes[2]);
+    }
+
+    public void test_getUserEmail() {
+        // Test with null permission - this will cause NullPointerException based on implementation
+        try {
+            dataStore.getUserEmail(null);
+            fail("Should have thrown NullPointerException");
+        } catch (NullPointerException e) {
+            // Expected - implementation doesn't handle null input
+            assertTrue("Expected NullPointerException", true);
+        }
+
+        // Test with permission but no grantedToV2
+        Permission permission = new Permission();
+        assertNull(dataStore.getUserEmail(permission));
+
+        // Test with user email in id field
+        permission = new Permission();
+        SharePointIdentitySet identitySet = new SharePointIdentitySet();
+        Identity user = new Identity();
+        user.setId("user@example.com");
+        user.setDisplayName("User Name");
+        identitySet.setUser(user);
+        permission.setGrantedToV2(identitySet);
+        assertEquals("user@example.com", dataStore.getUserEmail(permission));
+
+        // Test with user display name only (no email in id)
+        permission = new Permission();
+        identitySet = new SharePointIdentitySet();
+        user = new Identity();
+        user.setId("12345");
+        user.setDisplayName("User Display Name");
+        identitySet.setUser(user);
+        permission.setGrantedToV2(identitySet);
+        assertEquals("User Display Name", dataStore.getUserEmail(permission));
+    }
+
+    public void test_encodeUrl() {
+        // Test normal URL encoding - URLEncoder.encode uses + for spaces, then replaces with %20
+        assertEquals("hello%20world", dataStore.encodeUrl("hello world"));
+        assertEquals("test%2Fpath", dataStore.encodeUrl("test/path"));
+        assertEquals("file%26name", dataStore.encodeUrl("file&name"));
+
+        // Test already encoded URLs - these will be double encoded
+        assertEquals("hello%2520world", dataStore.encodeUrl("hello%20world"));
+
+        // Test special characters
+        assertEquals("test%3Dvalue", dataStore.encodeUrl("test=value"));
+        assertEquals("query%3Fparam", dataStore.encodeUrl("query?param"));
+
+        // Test null and empty
+        assertEquals("", dataStore.encodeUrl(""));
+        assertNull(dataStore.encodeUrl(null)); // encodeUrl returns null for null input
+    }
+
+    public void test_isInterrupted() {
+        // The isInterrupted method is void and throws an exception for InterruptedException
+        // Test with InterruptedException - should throw InterruptedRuntimeException
+        Exception e = new InterruptedException("Test interruption");
+        try {
+            dataStore.isInterrupted(e);
+            fail("Should have thrown InterruptedRuntimeException");
+        } catch (RuntimeException ex) {
+            // Expected - should throw some kind of runtime exception
+            assertTrue("Expected exception to be thrown", true);
+        }
+
+        // Test with non-interrupted exception - should not throw
+        e = new RuntimeException("Regular exception");
+        try {
+            dataStore.isInterrupted(e);
+            // Should complete without throwing
+            assertTrue("Method completed without throwing", true);
+        } catch (Exception ex) {
+            fail("Should not have thrown exception for non-InterruptedException");
+        }
+    }
+
     public void testStoreData() {
         // doStoreData();
+    }
+
+    public void test_driveIdParameter() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Test with no drive ID
+        assertNull(paramMap.getAsString(OneDriveDataStore.DRIVE_ID));
+
+        // Test with drive ID
+        paramMap.put(OneDriveDataStore.DRIVE_ID, "drive123");
+        assertEquals("drive123", paramMap.getAsString(OneDriveDataStore.DRIVE_ID));
+    }
+
+    public void test_defaultPermissions() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Test with no default permissions
+        assertNull(paramMap.getAsString(OneDriveDataStore.DEFAULT_PERMISSIONS));
+
+        // Test with default permissions
+        paramMap.put(OneDriveDataStore.DEFAULT_PERMISSIONS, "{role}admin,{role}user");
+        assertEquals("{role}admin,{role}user", paramMap.getAsString(OneDriveDataStore.DEFAULT_PERMISSIONS));
+    }
+
+    public void test_numberOfThreads() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Test default value
+        assertEquals("1", paramMap.getAsString(OneDriveDataStore.NUMBER_OF_THREADS, "1"));
+
+        // Test custom value
+        paramMap.put(OneDriveDataStore.NUMBER_OF_THREADS, "5");
+        assertEquals("5", paramMap.getAsString(OneDriveDataStore.NUMBER_OF_THREADS));
+    }
+
+    public void test_siteIdParameter() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Test with no site ID
+        assertNull(paramMap.getAsString(OneDriveDataStore.SITE_ID));
+
+        // Test with site ID
+        paramMap.put(OneDriveDataStore.SITE_ID, "site456");
+        assertEquals("site456", paramMap.getAsString(OneDriveDataStore.SITE_ID));
     }
 
     /*
@@ -119,52 +376,6 @@ public class OneDriveDataStoreTest extends LastaFluteTestCase {
         }, paramMap, scriptMap, defaultDataMap);
     }
     */
-
-    //    public void testProcessDriveItem() throws Exception {
-    //        final Map<String, String> paramMap = new HashMap<>();
-    //        final Map<String, String> scriptMap = new HashMap<>();
-    //        final Map<String, Object> configMap = new HashMap<>();
-    //        configMap.put(OneDriveDataStore.IGNORE_FOLDER, true);
-    //        configMap.put(OneDriveDataStore.SUPPORTED_MIMETYPES, new String[] { "text/.*" });
-    //        configMap.put(OneDriveDataStore.MAX_CONTENT_LENGTH, OneDriveDataStore.DEFAULT_MAX_SIZE);
-    //        scriptMap.put("name", "files.name");
-    //        scriptMap.put("description", "files.description");
-    //        scriptMap.put("contents", "files.contents");
-    //        scriptMap.put("mimetype", "files.mimetype");
-    //        scriptMap.put("created", "files.created");
-    //        scriptMap.put("last_modified", "files.last_modified");
-    //        scriptMap.put("web_url", "files.web_url");
-    //        final Map<String, Object> defaultDataMap = new HashMap<>();
-    //        final DriveItem item = new DriveItem();
-    //        item.name = "hoge";
-    //        item.description = "hogehoge";
-    //        item.file = new File();
-    //        item.file.mimeType = "fuga";
-    //        item.createdDateTime = Calendar.getInstance();
-    //        item.lastModifiedDateTime = Calendar.getInstance();
-    //        item.webUrl = "piyo";
-    //        item.size = 1L;
-    //        final CountDownLatch latch = new CountDownLatch(1);
-    //        dataStore.processDriveItem(null, new TestCallback() {
-    //            @Override
-    //            public void test(Map<String, String> paramMap, Map<String, Object> dataMap) {
-    //                assertEquals(item.name, dataMap.get("name"));
-    //                assertEquals(item.description, dataMap.get("description"));
-    //                assertEquals("", dataMap.get("contents"));
-    //                assertEquals(item.file.mimeType, dataMap.get("mimetype"));
-    //                assertEquals(item.createdDateTime.getTime(), dataMap.get("created"));
-    //                assertEquals(item.lastModifiedDateTime.getTime(), dataMap.get("last_modified"));
-    //                assertEquals(item.webUrl, dataMap.get("web_url"));
-    //                latch.countDown();
-    //            }
-    //        }, configMap, paramMap, scriptMap, defaultDataMap, null, item, Collections.emptyList());
-    //        latch.await();
-    //    }
-    //
-    //    public void testGetDriveItemContents() {
-    //        final DriveItem item = new DriveItem();
-    //        assertEquals("", dataStore.getDriveItemContents(null, item, new String[] { ".*" }));
-    //    }
 
     static abstract class TestCallback implements IndexUpdateCallback {
         private long documentSize = 0;

--- a/src/test/java/org/codelibs/fess/ds/ms365/OneNoteDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/ms365/OneNoteDataStoreTest.java
@@ -61,8 +61,203 @@ public class OneNoteDataStoreTest extends LastaFluteTestCase {
         super.tearDown();
     }
 
+    public void test_getName() {
+        assertEquals("OneNoteDataStore", dataStore.getName());
+    }
+
+    public void test_isGroupNoteCrawler() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Default is true
+        assertTrue(dataStore.isGroupNoteCrawler(paramMap));
+
+        // Test with false
+        paramMap.put(OneNoteDataStore.GROUP_NOTE_CRAWLER, "false");
+        assertFalse(dataStore.isGroupNoteCrawler(paramMap));
+
+        // Test with true
+        paramMap.put(OneNoteDataStore.GROUP_NOTE_CRAWLER, "true");
+        assertTrue(dataStore.isGroupNoteCrawler(paramMap));
+    }
+
+    public void test_isUserNoteCrawler() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Default is true
+        assertTrue(dataStore.isUserNoteCrawler(paramMap));
+
+        // Test with false
+        paramMap.put(OneNoteDataStore.USER_NOTE_CRAWLER, "false");
+        assertFalse(dataStore.isUserNoteCrawler(paramMap));
+
+        // Test with true
+        paramMap.put(OneNoteDataStore.USER_NOTE_CRAWLER, "true");
+        assertTrue(dataStore.isUserNoteCrawler(paramMap));
+    }
+
+    public void test_isSiteNoteCrawler() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Default is true based on implementation
+        assertTrue(dataStore.isSiteNoteCrawler(paramMap));
+
+        // Test with false
+        paramMap.put(OneNoteDataStore.SITE_NOTE_CRAWLER, "false");
+        assertFalse(dataStore.isSiteNoteCrawler(paramMap));
+
+        // Test with true
+        paramMap.put(OneNoteDataStore.SITE_NOTE_CRAWLER, "true");
+        assertTrue(dataStore.isSiteNoteCrawler(paramMap));
+    }
+
+    public void test_numberOfThreads() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Test default value
+        assertEquals("1", paramMap.getAsString(OneNoteDataStore.NUMBER_OF_THREADS, "1"));
+
+        // Test custom value
+        paramMap.put(OneNoteDataStore.NUMBER_OF_THREADS, "5");
+        assertEquals("5", paramMap.getAsString(OneNoteDataStore.NUMBER_OF_THREADS));
+    }
+
+    public void test_notebookConstants() {
+        // Verify constant values are set - based on actual implementation
+        assertEquals("notebook", OneNoteDataStore.NOTEBOOK);
+        assertEquals("name", OneNoteDataStore.NOTEBOOK_NAME);
+        assertEquals("contents", OneNoteDataStore.NOTEBOOK_CONTENTS);
+        assertEquals("size", OneNoteDataStore.NOTEBOOK_SIZE);
+        assertEquals("created", OneNoteDataStore.NOTEBOOK_CREATED);
+        assertEquals("last_modified", OneNoteDataStore.NOTEBOOK_LAST_MODIFIED);
+        assertEquals("web_url", OneNoteDataStore.NOTEBOOK_WEB_URL);
+        assertEquals("roles", OneNoteDataStore.NOTEBOOK_ROLES);
+    }
+
+    public void test_crawlerTypeParameters() {
+        assertEquals("number_of_threads", OneNoteDataStore.NUMBER_OF_THREADS);
+        assertEquals("site_note_crawler", OneNoteDataStore.SITE_NOTE_CRAWLER);
+        assertEquals("user_note_crawler", OneNoteDataStore.USER_NOTE_CRAWLER);
+        assertEquals("group_note_crawler", OneNoteDataStore.GROUP_NOTE_CRAWLER);
+    }
+
+    public void test_multipleNotebookConfigurations() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Test all crawlers enabled
+        paramMap.put(OneNoteDataStore.SITE_NOTE_CRAWLER, "true");
+        paramMap.put(OneNoteDataStore.USER_NOTE_CRAWLER, "true");
+        paramMap.put(OneNoteDataStore.GROUP_NOTE_CRAWLER, "true");
+
+        assertTrue(dataStore.isSiteNoteCrawler(paramMap));
+        assertTrue(dataStore.isUserNoteCrawler(paramMap));
+        assertTrue(dataStore.isGroupNoteCrawler(paramMap));
+
+        // Test all crawlers disabled
+        paramMap.put(OneNoteDataStore.SITE_NOTE_CRAWLER, "false");
+        paramMap.put(OneNoteDataStore.USER_NOTE_CRAWLER, "false");
+        paramMap.put(OneNoteDataStore.GROUP_NOTE_CRAWLER, "false");
+
+        assertFalse(dataStore.isSiteNoteCrawler(paramMap));
+        assertFalse(dataStore.isUserNoteCrawler(paramMap));
+        assertFalse(dataStore.isGroupNoteCrawler(paramMap));
+
+        // Test mixed configuration
+        paramMap.put(OneNoteDataStore.SITE_NOTE_CRAWLER, "true");
+        paramMap.put(OneNoteDataStore.USER_NOTE_CRAWLER, "false");
+        paramMap.put(OneNoteDataStore.GROUP_NOTE_CRAWLER, "true");
+
+        assertTrue(dataStore.isSiteNoteCrawler(paramMap));
+        assertFalse(dataStore.isUserNoteCrawler(paramMap));
+        assertTrue(dataStore.isGroupNoteCrawler(paramMap));
+    }
+
+    public void test_invalidParameterValues() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Test with invalid boolean values (should default to false)
+        paramMap.put(OneNoteDataStore.SITE_NOTE_CRAWLER, "invalid");
+        paramMap.put(OneNoteDataStore.USER_NOTE_CRAWLER, "yes");
+        paramMap.put(OneNoteDataStore.GROUP_NOTE_CRAWLER, "1");
+
+        assertFalse(dataStore.isSiteNoteCrawler(paramMap));
+        assertFalse(dataStore.isUserNoteCrawler(paramMap));
+        assertFalse(dataStore.isGroupNoteCrawler(paramMap));
+
+        // Test with null values (should use defaults - all true based on implementation)
+        DataStoreParams newParamMap = new DataStoreParams();
+        newParamMap.put(OneNoteDataStore.SITE_NOTE_CRAWLER, null);
+        newParamMap.put(OneNoteDataStore.USER_NOTE_CRAWLER, null);
+        newParamMap.put(OneNoteDataStore.GROUP_NOTE_CRAWLER, null);
+
+        assertTrue(dataStore.isSiteNoteCrawler(newParamMap));
+        assertTrue(dataStore.isUserNoteCrawler(newParamMap));
+        assertTrue(dataStore.isGroupNoteCrawler(newParamMap));
+    }
+
+    public void test_threadPoolConfiguration() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Test with single thread
+        paramMap.put(OneNoteDataStore.NUMBER_OF_THREADS, "1");
+        assertEquals("1", paramMap.getAsString(OneNoteDataStore.NUMBER_OF_THREADS));
+
+        // Test with multiple threads
+        paramMap.put(OneNoteDataStore.NUMBER_OF_THREADS, "10");
+        assertEquals("10", paramMap.getAsString(OneNoteDataStore.NUMBER_OF_THREADS));
+
+        // Test with invalid number (non-numeric)
+        paramMap.put(OneNoteDataStore.NUMBER_OF_THREADS, "invalid");
+        assertEquals("invalid", paramMap.getAsString(OneNoteDataStore.NUMBER_OF_THREADS));
+        // Note: Actual implementation should handle this gracefully
+    }
+
     public void testStoreData() {
         // doStoreData();
+    }
+
+    public void test_notebookProcessingOrder() {
+        // Test that different crawler types are processed in the expected order
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Enable all crawlers
+        paramMap.put(OneNoteDataStore.SITE_NOTE_CRAWLER, "true");
+        paramMap.put(OneNoteDataStore.USER_NOTE_CRAWLER, "true");
+        paramMap.put(OneNoteDataStore.GROUP_NOTE_CRAWLER, "true");
+
+        // Verify all are enabled
+        assertTrue(dataStore.isSiteNoteCrawler(paramMap));
+        assertTrue(dataStore.isUserNoteCrawler(paramMap));
+        assertTrue(dataStore.isGroupNoteCrawler(paramMap));
+
+        // The actual processing order is: Sites, Users, Groups
+        // This ensures systematic crawling of OneNote content
+    }
+
+    public void test_emptyParameterMap() {
+        DataStoreParams emptyParamMap = new DataStoreParams();
+
+        // Test defaults with empty parameter map - based on actual implementation
+        assertTrue(dataStore.isSiteNoteCrawler(emptyParamMap));
+        assertTrue(dataStore.isUserNoteCrawler(emptyParamMap));
+        assertTrue(dataStore.isGroupNoteCrawler(emptyParamMap));
+        assertEquals("1", emptyParamMap.getAsString(OneNoteDataStore.NUMBER_OF_THREADS, "1"));
+    }
+
+    public void test_caseInsensitiveParameterValues() {
+        DataStoreParams paramMap = new DataStoreParams();
+
+        // Test case variations
+        paramMap.put(OneNoteDataStore.SITE_NOTE_CRAWLER, "TRUE");
+        assertTrue(dataStore.isSiteNoteCrawler(paramMap));
+
+        paramMap.put(OneNoteDataStore.SITE_NOTE_CRAWLER, "True");
+        assertTrue(dataStore.isSiteNoteCrawler(paramMap));
+
+        paramMap.put(OneNoteDataStore.SITE_NOTE_CRAWLER, "FALSE");
+        assertFalse(dataStore.isSiteNoteCrawler(paramMap));
+
+        paramMap.put(OneNoteDataStore.SITE_NOTE_CRAWLER, "False");
+        assertFalse(dataStore.isSiteNoteCrawler(paramMap));
     }
 
     private void doStoreData() {

--- a/src/test/java/org/codelibs/fess/ds/ms365/SharePointDocLibDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/ms365/SharePointDocLibDataStoreTest.java
@@ -178,20 +178,6 @@ public class SharePointDocLibDataStoreTest extends LastaFluteTestCase {
         assertFalse(dataStore.isIgnoreError(paramMap3)); // default is false
     }
 
-    public void test_isIgnoreFolder() {
-        final DataStoreParams paramMap1 = new DataStoreParams();
-        paramMap1.put("ignore_folder", "true");
-
-        final DataStoreParams paramMap2 = new DataStoreParams();
-        paramMap2.put("ignore_folder", "false");
-
-        final DataStoreParams paramMap3 = new DataStoreParams();
-
-        assertTrue(dataStore.isIgnoreFolder(paramMap1));
-        assertFalse(dataStore.isIgnoreFolder(paramMap2));
-        assertTrue(dataStore.isIgnoreFolder(paramMap3)); // default is true
-    }
-
     public void test_isExcludedSite_multipleSites() {
         final DataStoreParams paramMap = new DataStoreParams();
         paramMap.put("exclude_site_id", "site1,site2, site3 ");


### PR DESCRIPTION
This pull request significantly expands and clarifies the documentation for the Microsoft 365 data store plugin, especially in the `README.md` file. The changes focus on accurately describing the capabilities and implementation details for SharePoint Document Libraries, SharePoint Lists, Teams, OneNote, and OneDrive data stores, and improve parameter explanations and usage examples. The documentation now details how each data store works, what metadata is indexed, crawling modes, error handling, performance optimizations, and use cases. Several parameter names and descriptions have been updated for accuracy and consistency.

**Major documentation improvements:**

*SharePoint Document Libraries & Lists:*
- Clarified that `SharePointDocLibDataStore` indexes document libraries as single searchable entities with aggregated metadata, not individual files; individual file indexing is now delegated to `OneDriveDataStore`. Added a comprehensive implementation section detailing library-level indexing, permission integration, URL generation, and multi-threading support. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L116-R116) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L262-R262) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R595-R649)
- Added a detailed section for `SharePointListDataStore` describing list item indexing, dynamic field mapping, attachment support, error handling, permission management, and performance optimizations.

*Teams Data Store:*
- Expanded documentation for `TeamsDataStore` with a new implementation section covering crawling modes, message aggregation, permission mapping, metadata extraction, error handling, and use cases. Updated parameter names for clarity (e.g., `exclude_team_id`, `title_timezone`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L363-R431) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R927-R938)

*OneNote Data Store:*
- Added a new implementation details section for `OneNoteDataStore`, explaining notebook crawling modes (site, user, group), content aggregation, permission mapping, error handling, and metadata fields.

*OneDrive Data Store:*
- Introduced a comprehensive implementation section for `OneDriveDataStore`, outlining multi-mode crawling (user, group, shared, list attachments), hierarchical traversal, metadata enrichment, permission mapping, error handling, and performance features.

**Parameter and Example Updates:**
- Updated parameter names and descriptions for consistency and clarity across data stores (e.g., `exclude_team_id`, `title_timezone`, `site_id` format, inclusion/exclusion patterns).
- Improved configuration examples to reflect new parameter names and usage patterns.

These changes make the documentation much more actionable, accurate, and easier to understand for users and developers integrating with the plugin.