### PR TITLE
Remove List Attachments crawling support and enhance SharePoint site recursion

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This plugin extends [Fess](https://fess.codelibs.org/) enterprise search capabil
 ## ✨ Key Features
 
 ### 📁 **Comprehensive Content Crawling**
-- **OneDrive**: User drives, group drives, shared documents, specific drives, and list attachments with metadata extraction
+- **OneDrive**: User drives, group drives, shared documents, and specific drives with metadata extraction
 - **OneNote**: Complete notebooks with aggregated content from all sections and pages, supporting site, user, and group notebooks
 - **Teams**: Channels, messages, chats with conversation context
 - **SharePoint Document Libraries**: Document library metadata indexing (libraries crawled as searchable entities, not individual files)
@@ -175,12 +175,6 @@ role=file.roles
 | file.search_result | Search result metadata (if file was found via search). |
 | file.special_folder | Special folder name (if file is in a special folder). |
 | file.video | Video metadata (for video files). |
-| file.source_type | Source type (e.g., "ListAttachment" for list attachments). |
-| file.site_id | SharePoint site ID (for list attachments). |
-| file.list_id | SharePoint list ID (for list attachments). |
-| file.list_item_id | SharePoint list item ID (for list attachments). |
-| file.list_title | SharePoint list title (for list attachments). |
-| file.list_item_title | SharePoint list item title (for list attachments). |
 
 #### OneNote
 
@@ -435,15 +429,6 @@ The implementation extracts comprehensive message metadata including:
 - **User Drives**: Enable `user_drive_crawler` to crawl all licensed users' OneDrive
 - **Group Drives**: Enable `group_drive_crawler` to crawl Microsoft 365 group drives
 - **Specific Drive**: Set `drive_id` to crawl only that specific drive
-- **List Attachments**: Enable `list_attachments_crawler` to crawl SharePoint list item attachments
-
-**List Attachments Crawling**:
-When `list_attachments_crawler` is enabled, the plugin crawls file attachments from SharePoint list items:
-- Crawls all sites or a specific site (using `site_id` parameter)
-- Filters lists by template type using `list_template_filter`
-- Processes each list item's attachments as virtual DriveItems
-- Includes additional metadata like site name, list title, and item information
-- Inherits site-level permissions for secure access
 
 ### OneNote-Specific Parameters
 
@@ -518,9 +503,6 @@ The implementation extracts and indexes the following notebook metadata:
 | `shared_documents_drive_crawler` | Enable shared documents crawling | `true` | Crawl default user's OneDrive |
 | `user_drive_crawler` | Enable user drives crawling | `true` | Crawl all licensed users' drives |
 | `group_drive_crawler` | Enable group drives crawling | `true` | Crawl Microsoft 365 group drives |
-| `list_attachments_crawler` | Enable list attachments crawling | `false` | Crawl SharePoint list item attachments |
-| `site_id` | Specific site ID for list attachments | - | Full site ID format for list attachments |
-| `list_template_filter` | Filter lists by template type | `documentLibrary,genericList` | Comma-separated template types |
 
 #### OneDrive Crawling Implementation
 
@@ -531,7 +513,6 @@ The OneDriveDataStore provides comprehensive Microsoft 365 file crawling capabil
 - **User Drives**: Iterates through all licensed users and crawls their OneDrive (`/users/{userId}/drive`)
 - **Group Drives**: Crawls Microsoft 365 group-associated drives (`/groups/{groupId}/drive`)
 - **Specific Drive**: Targets a single drive by ID (`/drives/{driveId}`)
-- **List Attachments**: Extracts file attachments from SharePoint list items across sites
 
 **Content Processing Pipeline:**
 1. **Drive Discovery**: Uses Microsoft Graph API to enumerate drives based on crawling mode
@@ -700,9 +681,10 @@ The implementation intelligently extracts content from list items:
 - Inherits site and list-level permissions for items
 
 **Attachment Support:**
-- Detects and processes file attachments on list items
-- Extracts attachment metadata including names and URLs
-- Includes attachment information in indexed content
+- **List Item Attachments**: Detects and processes file attachments on SharePoint list items
+- **Attachment Metadata**: Extracts attachment metadata including names, URLs, and file information
+- **Content Integration**: Includes attachment information in indexed content for comprehensive search
+- **Secure Access**: Inherits SharePoint permissions for proper access control to attached files
 
 **URL Filtering:**
 - **Include Pattern**: Regex-based filtering to include specific items by title
@@ -713,6 +695,7 @@ The implementation intelligently extracts content from list items:
 - **Structured Data Search**: Index and search custom business data stored in SharePoint lists
 - **Task and Issue Tracking**: Search across task lists, issue trackers, and project lists
 - **Document Metadata**: Index document libraries managed as SharePoint lists
+- **List Attachments**: Search file attachments uploaded to SharePoint list items
 - **Custom Applications**: Search data from Power Apps and custom SharePoint solutions
 - **Business Process Content**: Index workflow-related lists and approval items
 

--- a/src/test/java/org/codelibs/fess/ds/ms365/OneDriveDataStoreTest.java
+++ b/src/test/java/org/codelibs/fess/ds/ms365/OneDriveDataStoreTest.java
@@ -143,18 +143,6 @@ public class OneDriveDataStoreTest extends LastaFluteTestCase {
         assertTrue(dataStore.isGroupDriveCrawler(paramMap));
     }
 
-    public void test_isListAttachmentsCrawler() {
-        DataStoreParams paramMap = new DataStoreParams();
-
-        assertFalse(dataStore.isListAttachmentsCrawler(paramMap)); // default is false
-
-        paramMap.put(OneDriveDataStore.LIST_ATTACHMENTS_CRAWLER, "false");
-        assertFalse(dataStore.isListAttachmentsCrawler(paramMap));
-
-        paramMap.put(OneDriveDataStore.LIST_ATTACHMENTS_CRAWLER, "true");
-        assertTrue(dataStore.isListAttachmentsCrawler(paramMap));
-    }
-
     public void test_isIgnoreFolder() {
         DataStoreParams paramMap = new DataStoreParams();
 
@@ -331,17 +319,6 @@ public class OneDriveDataStoreTest extends LastaFluteTestCase {
         // Test custom value
         paramMap.put(OneDriveDataStore.NUMBER_OF_THREADS, "5");
         assertEquals("5", paramMap.getAsString(OneDriveDataStore.NUMBER_OF_THREADS));
-    }
-
-    public void test_siteIdParameter() {
-        DataStoreParams paramMap = new DataStoreParams();
-
-        // Test with no site ID
-        assertNull(paramMap.getAsString(OneDriveDataStore.SITE_ID));
-
-        // Test with site ID
-        paramMap.put(OneDriveDataStore.SITE_ID, "site456");
-        assertEquals("site456", paramMap.getAsString(OneDriveDataStore.SITE_ID));
     }
 
     /*


### PR DESCRIPTION
This pull request refactors the SharePoint list crawling logic to support recursive crawling of all SharePoint sites and sub-sites, improves error handling and thread management, and removes legacy support for list attachments in OneDrive crawling. The documentation is updated to reflect these changes, and related tests are cleaned up. The most important changes are grouped below:

### SharePoint Site Crawling Improvements

* Refactored `SharePointListDataStore` to crawl all SharePoint sites and their sub-sites recursively if `site_id` is not specified, using the new `getSiteChildren` method in `Microsoft365Client`. This enables comprehensive site coverage. [[1]](diffhunk://#diff-4db0626657b9b48119508463ac19311712f15ed6abea20b64d116ce62937b5f7L159-R204) [[2]](diffhunk://#diff-9779ffde552d4034c2a15b03db90562d21c977e89b59882f070e13385d200faaL733-R736) [[3]](diffhunk://#diff-9779ffde552d4034c2a15b03db90562d21c977e89b59882f070e13385d200faaR758-R818)
* Improved thread management and error handling in `SharePointListDataStore`, ensuring proper shutdown and more robust exception propagation. [[1]](diffhunk://#diff-4db0626657b9b48119508463ac19311712f15ed6abea20b64d116ce62937b5f7L159-R204) [[2]](diffhunk://#diff-4db0626657b9b48119508463ac19311712f15ed6abea20b64d116ce62937b5f7L228-R271) [[3]](diffhunk://#diff-4db0626657b9b48119508463ac19311712f15ed6abea20b64d116ce62937b5f7L238-L247)

### Removal of List Attachments Support in OneDrive

* Removed support for crawling SharePoint list item attachments from OneDrive crawling logic and documentation. This includes code, documentation, and metadata field removals. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L178-L183) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L438-L446) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L521-L523) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L534) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L703-R687) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R698)

### Microsoft365Client Enhancements

* Added recursive sub-site crawling logic to `Microsoft365Client#getSites` and introduced `getSiteChildren` for paginated child site retrieval. [[1]](diffhunk://#diff-9779ffde552d4034c2a15b03db90562d21c977e89b59882f070e13385d200faaL733-R736) [[2]](diffhunk://#diff-9779ffde552d4034c2a15b03db90562d21c977e89b59882f070e13385d200faaR758-R818)
* Simplified drive item attachment retrieval and removed legacy error handling for document library checks. [[1]](diffhunk://#diff-9779ffde552d4034c2a15b03db90562d21c977e89b59882f070e13385d200faaL1711-R1776) [[2]](diffhunk://#diff-9779ffde552d4034c2a15b03db90562d21c977e89b59882f070e13385d200faaL1784-L1790)

### Test Suite Cleanup

* Removed obsolete tests related to list attachment crawling and site ID parameter handling in `OneDriveDataStoreTest`. [[1]](diffhunk://#diff-89005a78bc46d121ab2972af4202f02e9de070f287ec4fcb6f44bb5855503741L146-L157) [[2]](diffhunk://#diff-89005a78bc46d121ab2972af4202f02e9de070f287ec4fcb6f44bb5855503741L336-L346)