### PR TITLE
Remove unsupported $select and $orderby parameters from chat message requests

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java
+++ b/src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java
@@ -1411,15 +1411,8 @@ public class Microsoft365Client implements Closeable {
 
         try {
             // Microsoft Graph SDK v6 uses requestConfiguration instead of QueryOption
-            ChatMessageCollectionResponse response = client.chats().byChatId(chatId).messages().get(requestConfiguration -> {
-                // Select only essential fields to improve performance
-                requestConfiguration.queryParameters.select =
-                        new String[] { "id", "body", "from", "createdDateTime", "attachments", "messageType" };
-                requestConfiguration.queryParameters.orderby = new String[] { "createdDateTime desc" };
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Request configured with select fields and orderby=createdDateTime desc for chat: {}", chatId);
-                }
-            });
+            // Chat message endpoint rejects $select/$orderby; rely on default projection.
+            ChatMessageCollectionResponse response = client.chats().byChatId(chatId).messages().get();
 
             int pageCount = 0;
             int totalMessages = 0;


### PR DESCRIPTION
This update modifies the Microsoft365Client to avoid using $select and $orderby query parameters when retrieving chat messages. The Microsoft Graph chat message endpoint does not support these parameters, so the request is simplified to use the default projection. This change prevents potential request rejections and ensures compatibility with the Graph API.
