### PR TITLE
Fix client-side sorting for Teams channel messages

### DIFF
--- a/src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java
+++ b/src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java
@@ -1232,10 +1232,18 @@ public class Microsoft365Client implements Closeable {
 
         // Handle pagination with odata.nextLink
         while (response != null && response.getValue() != null) {
+<<<<<<< Updated upstream
             response.getValue().stream()
                 .filter(java.util.Objects::nonNull)
                 .sorted(Comparator.comparing(Channel::getDisplayName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
                 .forEach(consumer::accept);
+=======
+            response.getValue()
+                    .stream()
+                    .filter(java.util.Objects::nonNull)
+                    .sorted(Comparator.comparing(Channel::getDisplayName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
+                    .forEach(consumer::accept);
+>>>>>>> Stashed changes
 
             // Check if there's a next page
             if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {
@@ -1287,12 +1295,19 @@ public class Microsoft365Client implements Closeable {
                     // Select only essential fields to improve performance
                     requestConfiguration.queryParameters.select =
                             new String[] { "id", "body", "from", "createdDateTime", "attachments", "messageType" };
-                    requestConfiguration.queryParameters.orderby = new String[] { "createdDateTime desc" };
+                    // Note: $orderby is not supported by the channel messages API
+                    // Client-side sorting is applied below instead
                 });
 
         // Handle pagination with odata.nextLink
         while (response != null && response.getValue() != null) {
-            response.getValue().forEach(consumer::accept);
+            // Sort messages by createdDateTime in descending order (newest first)
+            // API doesn't support $orderby, so we sort client-side
+            response.getValue()
+                    .stream()
+                    .filter(java.util.Objects::nonNull)
+                    .sorted(Comparator.comparing(ChatMessage::getCreatedDateTime, Comparator.nullsLast(Comparator.reverseOrder())))
+                    .forEach(consumer::accept);
 
             // Check if there's a next page
             if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {

--- a/src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java
+++ b/src/main/java/org/codelibs/fess/ds/ms365/client/Microsoft365Client.java
@@ -1232,18 +1232,11 @@ public class Microsoft365Client implements Closeable {
 
         // Handle pagination with odata.nextLink
         while (response != null && response.getValue() != null) {
-<<<<<<< Updated upstream
-            response.getValue().stream()
-                .filter(java.util.Objects::nonNull)
-                .sorted(Comparator.comparing(Channel::getDisplayName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
-                .forEach(consumer::accept);
-=======
             response.getValue()
                     .stream()
                     .filter(java.util.Objects::nonNull)
                     .sorted(Comparator.comparing(Channel::getDisplayName, Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER)))
                     .forEach(consumer::accept);
->>>>>>> Stashed changes
 
             // Check if there's a next page
             if (response.getOdataNextLink() == null || response.getOdataNextLink().isEmpty()) {


### PR DESCRIPTION
## Summary

This PR fixes the Teams channel messages retrieval by removing the unsupported `$orderby` parameter and implementing client-side sorting instead.

## Changes Made

- **Removed unsupported API parameter**: The Microsoft Graph API for channel messages (`/teams/{team-id}/channels/{channel-id}/messages`) does not support the `$orderby` query parameter, which was causing API errors
- **Implemented client-side sorting**: Added sorting by `createdDateTime` in descending order (newest first) after fetching the response
- **Applied consistent formatting**: Updated the channel list sorting logic to use consistent code formatting
- **Added inline documentation**: Included a comment explaining why server-side ordering is not available

## Technical Details

The change affects the `getChannelMessages` method in `Microsoft365Client.java`:
- Removed `requestConfiguration.queryParameters.orderby = new String[] { "createdDateTime desc" };`
- Added client-side sorting using `Comparator.comparing(ChatMessage::getCreatedDateTime, Comparator.nullsLast(Comparator.reverseOrder()))`
- Applied null-safe filtering before sorting to prevent NullPointerExceptions

## Testing

- Manual testing confirmed that messages are now retrieved successfully and sorted correctly
- No breaking changes to the public API

## Breaking Changes

None - this is a bug fix that maintains the expected behavior while using a supported approach.